### PR TITLE
Fix Python test failing when upgrading `junit-jupiter-api`

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -32,4 +32,4 @@ jobs:
 
     # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
     - name: Update dependency graph
-      uses: advanced-security/maven-dependency-submission-action@5d0f9011b55d6268922128af45275986303459c3
+      uses: advanced-security/maven-dependency-submission-action@v4

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,13 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>5.10.3</version> <!-- version 5.10.2 break python tests-->
+            <version>5.10.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <version>1.11.0-M2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>5.9.3</version> <!-- version 5.10.2 break python tests-->
+            <version>5.10.3</version> <!-- version 5.10.2 break python tests-->
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Adds the following dependency:
```
        <dependency>
            <groupId>org.junit.platform</groupId>
            <artifactId>junit-platform-launcher</artifactId>
            <version>1.11.0-M2</version>
            <scope>test</scope>
        </dependency>
```
as suggested [here](https://stackoverflow.com/questions/77241793/nosuchmethoderror-java-util-set-org-junit-platform-engine-testdescriptor-getan).

This allows to fix the Python tests when upgrading `junit-jupiter-api` to a version higher than 5.9.3. 
This also fixes the CI problem in "Update dependency graph" which was just a  consequence of the Python tests failing.