### PR TITLE
Fix/sonar 10.x support

### DIFF
--- a/java/src/main/java/com/ibm/plugin/JavaCheckRegistrar.java
+++ b/java/src/main/java/com/ibm/plugin/JavaCheckRegistrar.java
@@ -30,7 +30,6 @@ public class JavaCheckRegistrar implements CheckRegistrar {
     @Override
     public void register(RegistrarContext registrarContext) {
         // Call to registerClassesForRepository to associate the classes with the correct repository
-        // keyfactory
         registrarContext.registerClassesForRepository(
                 JavaScannerRuleDefinition.REPOSITORY_KEY, checkClasses(), testCheckClasses());
     }

--- a/java/src/main/java/com/ibm/plugin/JavaScannerRuleDefinition.java
+++ b/java/src/main/java/com/ibm/plugin/JavaScannerRuleDefinition.java
@@ -19,12 +19,14 @@
  */
 package com.ibm.plugin;
 
+import org.sonar.api.SonarRuntime;
+import org.sonar.api.server.rule.RulesDefinition;
+import org.sonar.plugins.java.Java;
+import org.sonarsource.analyzer.commons.RuleMetadataLoader;
+
 import java.util.Collections;
 import java.util.Objects;
 import java.util.Set;
-import org.sonar.api.SonarRuntime;
-import org.sonar.api.server.rule.RulesDefinition;
-import org.sonarsource.analyzer.commons.RuleMetadataLoader;
 
 public class JavaScannerRuleDefinition implements RulesDefinition {
     public static final String REPOSITORY_KEY = "sonar-java-crypto";
@@ -44,20 +46,17 @@ public class JavaScannerRuleDefinition implements RulesDefinition {
     @Override
     public void define(Context context) {
         NewRepository repository =
-                context.createRepository(REPOSITORY_KEY, "java").setName(REPOSITORY_NAME);
+                context.createRepository(REPOSITORY_KEY, Java.KEY).setName(REPOSITORY_NAME);
 
         RuleMetadataLoader ruleMetadataLoader =
-                new RuleMetadataLoader(RESOURCE_BASE_PATH, sonarRuntime);
+                new RuleMetadataLoader(RESOURCE_BASE_PATH, this.sonarRuntime);
         ruleMetadataLoader.addRulesByAnnotatedClass(repository, JavaRuleList.getChecks());
 
-        setTemplates(repository);
-        repository.done();
-    }
-
-    private static void setTemplates(NewRepository repository) {
         RULE_TEMPLATES_KEY.stream()
                 .map(repository::rule)
                 .filter(Objects::nonNull)
                 .forEach(rule -> rule.setTemplate(true));
+
+        repository.done();
     }
 }

--- a/java/src/main/java/com/ibm/plugin/JavaScannerRuleDefinition.java
+++ b/java/src/main/java/com/ibm/plugin/JavaScannerRuleDefinition.java
@@ -19,14 +19,13 @@
  */
 package com.ibm.plugin;
 
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Set;
 import org.sonar.api.SonarRuntime;
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.plugins.java.Java;
 import org.sonarsource.analyzer.commons.RuleMetadataLoader;
-
-import java.util.Collections;
-import java.util.Objects;
-import java.util.Set;
 
 public class JavaScannerRuleDefinition implements RulesDefinition {
     public static final String REPOSITORY_KEY = "sonar-java-crypto";

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
         <checkstyle.version>10.15.0</checkstyle.version>
 
         <sonar.version>10.6.0.92116</sonar.version>
+        <sonar.minVersion>9.14.0.375</sonar.minVersion>
         <sonar.plugin.api.version>10.10.0.2391</sonar.plugin.api.version>
         <!-- language parser versions -->
         <sonar.java.version>8.1.0.36477</sonar.java.version>

--- a/python/src/main/java/com/ibm/plugin/rules/PythonInventoryRule.java
+++ b/python/src/main/java/com/ibm/plugin/rules/PythonInventoryRule.java
@@ -23,6 +23,8 @@ import com.ibm.engine.detection.DetectionStore;
 import com.ibm.engine.rule.IDetectionRule;
 import com.ibm.plugin.rules.detection.PythonBaseDetectionRule;
 import com.ibm.plugin.rules.detection.PythonDetectionRules;
+import java.util.List;
+import javax.annotation.Nonnull;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Unmodifiable;
 import org.jetbrains.annotations.VisibleForTesting;
@@ -31,9 +33,6 @@ import org.sonar.plugins.python.api.PythonCheck;
 import org.sonar.plugins.python.api.PythonVisitorContext;
 import org.sonar.plugins.python.api.symbols.Symbol;
 import org.sonar.plugins.python.api.tree.Tree;
-
-import javax.annotation.Nonnull;
-import java.util.List;
 
 @Rule(key = "Inventory")
 public class PythonInventoryRule extends PythonBaseDetectionRule {

--- a/sonar-cryptography-plugin/pom.xml
+++ b/sonar-cryptography-plugin/pom.xml
@@ -58,10 +58,10 @@
                     <pluginKey>sonar-crypto-plugin</pluginKey>
                     <pluginName>Sonar Crypto Plugin</pluginName>
                     <pluginClass>com.ibm.plugin.CryptographyPlugin</pluginClass>
-                    <pluginApiMinVersion>${sonar.version}</pluginApiMinVersion>
+                    <pluginApiMinVersion>${sonar.minVersion}</pluginApiMinVersion>
                     <sonarLintSupported>true</sonarLintSupported>
                     <skipDependenciesPackaging>true</skipDependenciesPackaging>
-                    <jreMinVersion>${sonar.jreMinVersion}</jreMinVersion>
+                    <jreMinVersion>17</jreMinVersion>
                 </configuration>
             </plugin>
             <plugin>

--- a/sonar-cryptography-plugin/src/main/java/com/ibm/plugin/CryptographyPlugin.java
+++ b/sonar-cryptography-plugin/src/main/java/com/ibm/plugin/CryptographyPlugin.java
@@ -21,10 +21,11 @@ package com.ibm.plugin;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.sonar.api.Plugin;
 import org.sonar.api.SonarProduct;
 import org.sonar.api.SonarRuntime;
 
-public class CryptographyPlugin implements org.sonar.api.Plugin {
+public class CryptographyPlugin implements Plugin {
 
     @SuppressWarnings({"java:S1874"})
     private static final Logger LOGGER = LoggerFactory.getLogger(CryptographyPlugin.class);

--- a/sonar-cryptography-plugin/src/test/java/com/ibm/plugin/JavaFileCheckRegistrarTest.java
+++ b/sonar-cryptography-plugin/src/test/java/com/ibm/plugin/JavaFileCheckRegistrarTest.java
@@ -19,24 +19,21 @@
  */
 package com.ibm.plugin;
 
-import java.util.List;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Unmodifiable;
-import org.sonar.api.config.PropertyDefinition;
-import org.sonar.api.resources.Qualifiers;
+import static org.assertj.core.api.Assertions.assertThat;
 
-public final class Configuration {
+import org.junit.jupiter.api.Test;
+import org.sonar.plugins.java.api.CheckRegistrar;
 
-    private Configuration() {}
+class JavaFileCheckRegistrarTest {
 
-    public static @NotNull @Unmodifiable List<PropertyDefinition> getPropertyDefinitions() {
-        return List.of(
-                PropertyDefinition.builder(Constants.CBOM_OUTPUT_NAME)
-                        .onQualifiers(Qualifiers.PROJECT)
-                        .subCategory(Constants.SUB_CATEGORY_GENERAL)
-                        .name("CBOM filename")
-                        .description("Filename for the generated CBOM")
-                        .defaultValue(Constants.CBOM_OUTPUT_NAME_DEFAULT)
-                        .build());
+    @Test
+    void checkNumberRules() {
+        CheckRegistrar.RegistrarContext context = new CheckRegistrar.RegistrarContext();
+
+        JavaCheckRegistrar registrar = new JavaCheckRegistrar();
+        registrar.register(context);
+
+        assertThat(context.checkClasses()).hasSize(1);
+        assertThat(context.testCheckClasses()).isEmpty();
     }
 }


### PR DESCRIPTION
Add support for SonarQube 10.x.

I have to heck if this build of the plugin can also be used for sonar 9.x (my assumption is, yes, but I have to test it).

If that works, we can:

- [ ] create a 2.0.0 release
- [ ] remove `dev/1.x.x`

