### PR TITLE
Fix GitHub Packages workflow

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -5,7 +5,8 @@ name: Publish package to GitHub Packages
 
 on:
   release:
-    types: [created]
+    types: [published]
+  workflow_dispatch:
 
 jobs:
   build-java-17:


### PR DESCRIPTION
- Use `published` event instead of `created`
- Add `workflow_dispatch` to [manually trigger the event](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow) if necessary