### PR TITLE
pin supported SonarQube version in docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ in source code and generates [CBOM](https://cyclonedx.org/capabilities/cbom/).
 | 1.2.0 and up   | SonarQube 9.8 and up              |      
 
 > [!WARNING]
-> There is an issue with SonarQube versions `10.5.0` and above that affects the functionality of our plugin. Specifically, our custom rules are not being executed correctly, resulting in no detections. This problem is due to an issue on the SonarQube side and is being tracked on [this discussion](https://community.sonarsource.com/t/custom-java-rules-are-not-executed-after-sonar-api-upgrade-from-9-x-to-10-x/119621) of the Sonar Community forum.
+> SonarQube versions `10.5.0` and above affects the functionality of our plugin. Specifically, our custom rules are not being executed correctly, resulting in no detections. This problem is due to a change on the SonarQube side ([see](https://community.sonarsource.com/t/custom-java-rules-are-not-executed-after-sonar-api-upgrade-from-9-x-to-10-x/119621)).
 
 ## Supported languages and libraries
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   sonarqube:
-    image: sonarqube:10-community
+    image: sonarqube:10.5-community
     user: "${UID}"
     volumes:
       - sonar-data:/opt/sonarqube/data

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   sonarqube:
-    image: sonarqube:10.5-community
+    image: sonarqube:10.4-community
     user: "${UID}"
     volumes:
       - sonar-data:/opt/sonarqube/data


### PR DESCRIPTION
SonarQube versions 10.5.0 and above affects the functionality of our plugin. Specifically, our custom rules are not being executed correctly, resulting in no detections. This problem is due to an change on the SonarQube side.

In the recent SonarQube versions, we have introduced a mechanism to skip downloading/loading language plugins if they are obviously useless.

- The Scanner load first non-lazy plugins
- The Scanner list the project files to analyze
- The Scanner load lazy plugins, based on files present in the project

SonarJava is lazy, and is only loaded in the second phase if [java and jsp](https://github.com/SonarSource/sonar-java/blob/bd398e152b95f248d7bc6043e7011d0a0355eccb/sonar-java-plugin/pom.xml#L148) files are there.

So a simple fix for you is to also make you plugin lazy, and ensure its loading condition is at least as restrictive as plugins it depends on.

But the problem here is your plugin depends on 2 lazy Sonar plugins, so this is not a situation we support anymore. You will have to split your plugin in 2 different plugins (one for Java, one for Python).