### PR TITLE
Fix issue #12

### DIFF
--- a/java/src/test/java/com/ibm/plugin/rules/issues/DuplicateDependingRules2Test.java
+++ b/java/src/test/java/com/ibm/plugin/rules/issues/DuplicateDependingRules2Test.java
@@ -41,7 +41,7 @@ import org.sonar.plugins.java.api.JavaFileScannerContext;
 import org.sonar.plugins.java.api.semantic.Symbol;
 import org.sonar.plugins.java.api.tree.Tree;
 
-public class DuplicateDependingRules2Test extends TestBase {
+class DuplicateDependingRules2Test extends TestBase {
 
     static IDetectionContext detectionContext =
             new IDetectionContext() {
@@ -96,7 +96,7 @@ public class DuplicateDependingRules2Test extends TestBase {
 
         List<DetectionStore<JavaCheck, Tree, Symbol, JavaFileScannerContext>> stores =
                 getStoresOfValueType(Algorithm.class, detectionStore.getChildren());
-        assertThat(stores).hasSize(3);
+        assertThat(stores).hasSize(2);
 
         DetectionStore<JavaCheck, Tree, Symbol, JavaFileScannerContext> store_1 = stores.get(0);
         assertThat(store_1.getDetectionValues()).hasSize(1);


### PR DESCRIPTION
@hugoqnc I've checked that this doesn't break any other tests in Java, but I haven't checked it for BC. Please do so before we merge this PR.

Should fix #12

## How the fix works
If a `shouldBeDetectedAs` defined as part of a detection rule and if this detection should be append as a child to another value (by using `asChildOfParameterWithId(...)`) then this detection value does not get the root depending detection rules appended (done with `withDependingDetectionRules`). 

If more then one detection value should be detected on root level (both don't use `asChildOfParameterWithId(...)`) then, this will still create duplicated nodes on the lower levels. But as part of the translation procedure, this should be merged automatically. 


