### PR TITLE
Fix JUnit issue with Python tests 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.11.0</version>
+            <scope>test</scope>
+        </dependency> 
+        <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-launcher</artifactId>
             <version>1.11.0</version>

--- a/python/src/test/java/com/ibm/plugin/rules/detection/aead/PycaAESGCMTest.java
+++ b/python/src/test/java/com/ibm/plugin/rules/detection/aead/PycaAESGCMTest.java
@@ -40,17 +40,17 @@ import com.ibm.mapper.model.functionality.KeyGeneration;
 import com.ibm.plugin.TestBase;
 import java.util.List;
 import javax.annotation.Nonnull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.plugins.python.api.PythonCheck;
 import org.sonar.plugins.python.api.PythonVisitorContext;
 import org.sonar.plugins.python.api.symbols.Symbol;
 import org.sonar.plugins.python.api.tree.Tree;
 import org.sonar.python.checks.utils.PythonCheckVerifier;
 
-public class PycaAESGCMTest extends TestBase {
+class PycaAESGCMTest extends TestBase {
 
     @Test
-    public void test() {
+    void test() {
         PythonCheckVerifier.verify(
                 "src/test/files/rules/detection/aead/PycaAESGCMTestFile.py", this);
     }

--- a/python/src/test/java/com/ibm/plugin/rules/detection/aead/PycaChaCha20Poly1305Test.java
+++ b/python/src/test/java/com/ibm/plugin/rules/detection/aead/PycaChaCha20Poly1305Test.java
@@ -36,20 +36,19 @@ import com.ibm.mapper.model.functionality.Digest;
 import com.ibm.mapper.model.functionality.Encrypt;
 import com.ibm.mapper.model.functionality.KeyGeneration;
 import com.ibm.plugin.TestBase;
-import com.ibm.plugin.utils.GenerateAssertsHelper;
 import java.util.List;
 import javax.annotation.Nonnull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.plugins.python.api.PythonCheck;
 import org.sonar.plugins.python.api.PythonVisitorContext;
 import org.sonar.plugins.python.api.symbols.Symbol;
 import org.sonar.plugins.python.api.tree.Tree;
 import org.sonar.python.checks.utils.PythonCheckVerifier;
 
-public class PycaChaCha20Poly1305Test extends TestBase {
+class PycaChaCha20Poly1305Test extends TestBase {
 
     @Test
-    public void test() {
+    void test() {
         PythonCheckVerifier.verify(
                 "src/test/files/rules/detection/aead/PycaChaCha20Poly1305TestFile.py", this);
     }
@@ -82,8 +81,6 @@ public class PycaChaCha20Poly1305Test extends TestBase {
         assertThat(store.getDetectionValueContext()).isInstanceOf(CipherContext.class);
         assertThat(encryptValue).isInstanceOf(CipherAction.class);
         assertThat(encryptValue.asString()).isEqualTo("DECRYPT");
-
-        GenerateAssertsHelper.generate(detectionStore, nodes);
 
         /*
          * Translation

--- a/python/src/test/java/com/ibm/plugin/rules/detection/asymmetric/DSA/PycaDSANumbersTest.java
+++ b/python/src/test/java/com/ibm/plugin/rules/detection/asymmetric/DSA/PycaDSANumbersTest.java
@@ -35,17 +35,17 @@ import com.ibm.mapper.model.functionality.KeyGeneration;
 import com.ibm.plugin.TestBase;
 import java.util.List;
 import javax.annotation.Nonnull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.plugins.python.api.PythonCheck;
 import org.sonar.plugins.python.api.PythonVisitorContext;
 import org.sonar.plugins.python.api.symbols.Symbol;
 import org.sonar.plugins.python.api.tree.Tree;
 import org.sonar.python.checks.utils.PythonCheckVerifier;
 
-public class PycaDSANumbersTest extends TestBase {
+class PycaDSANumbersTest extends TestBase {
 
     @Test
-    public void test() {
+    void test() {
         PythonCheckVerifier.verify(
                 "src/test/files/rules/detection/asymmetric/DSA/PycaDSANumbersTestFile.py", this);
     }

--- a/python/src/test/java/com/ibm/plugin/rules/detection/asymmetric/DSA/PycaDSASignTest.java
+++ b/python/src/test/java/com/ibm/plugin/rules/detection/asymmetric/DSA/PycaDSASignTest.java
@@ -42,17 +42,17 @@ import com.ibm.mapper.model.functionality.Sign;
 import com.ibm.plugin.TestBase;
 import java.util.List;
 import javax.annotation.Nonnull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.plugins.python.api.PythonCheck;
 import org.sonar.plugins.python.api.PythonVisitorContext;
 import org.sonar.plugins.python.api.symbols.Symbol;
 import org.sonar.plugins.python.api.tree.Tree;
 import org.sonar.python.checks.utils.PythonCheckVerifier;
 
-public class PycaDSASignTest extends TestBase {
+class PycaDSASignTest extends TestBase {
 
     @Test
-    public void test() {
+    void test() {
         PythonCheckVerifier.verify(
                 "src/test/files/rules/detection/asymmetric/DSA/PycaDSASignTestFile.py", this);
     }

--- a/python/src/test/java/com/ibm/plugin/rules/detection/asymmetric/DiffieHellman/PycaDiffieHellmanGenerateTest.java
+++ b/python/src/test/java/com/ibm/plugin/rules/detection/asymmetric/DiffieHellman/PycaDiffieHellmanGenerateTest.java
@@ -33,7 +33,7 @@ import com.ibm.mapper.model.functionality.KeyGeneration;
 import com.ibm.plugin.TestBase;
 import java.util.List;
 import javax.annotation.Nonnull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.plugins.python.api.PythonCheck;
 import org.sonar.plugins.python.api.PythonVisitorContext;
 import org.sonar.plugins.python.api.symbols.Symbol;
@@ -45,7 +45,7 @@ public final class PycaDiffieHellmanGenerateTest extends TestBase {
     // The key size does not yet appear because
     // of the TraceSymbol problem documented on the Github issue
     @Test
-    public void test() {
+    void test() {
         PythonCheckVerifier.verify(
                 "src/test/files/rules/detection/asymmetric/DiffieHellman/PycaDiffieHellmanGenerateTestFile.py",
                 this);

--- a/python/src/test/java/com/ibm/plugin/rules/detection/asymmetric/DiffieHellman/PycaDiffieHellmanNumbersTest.java
+++ b/python/src/test/java/com/ibm/plugin/rules/detection/asymmetric/DiffieHellman/PycaDiffieHellmanNumbersTest.java
@@ -33,17 +33,17 @@ import com.ibm.mapper.model.functionality.KeyGeneration;
 import com.ibm.plugin.TestBase;
 import java.util.List;
 import javax.annotation.Nonnull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.plugins.python.api.PythonCheck;
 import org.sonar.plugins.python.api.PythonVisitorContext;
 import org.sonar.plugins.python.api.symbols.Symbol;
 import org.sonar.plugins.python.api.tree.Tree;
 import org.sonar.python.checks.utils.PythonCheckVerifier;
 
-public class PycaDiffieHellmanNumbersTest extends TestBase {
+class PycaDiffieHellmanNumbersTest extends TestBase {
 
     @Test
-    public void test() {
+    void test() {
         PythonCheckVerifier.verify(
                 "src/test/files/rules/detection/asymmetric/DiffieHellman/PycaDiffieHellmanNumbersTestFile.py",
                 this);

--- a/python/src/test/java/com/ibm/plugin/rules/detection/asymmetric/EllipticCurve/PycaEllipticCurveDeriveTest.java
+++ b/python/src/test/java/com/ibm/plugin/rules/detection/asymmetric/EllipticCurve/PycaEllipticCurveDeriveTest.java
@@ -34,17 +34,17 @@ import com.ibm.mapper.model.functionality.KeyGeneration;
 import com.ibm.plugin.TestBase;
 import java.util.List;
 import javax.annotation.Nonnull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.plugins.python.api.PythonCheck;
 import org.sonar.plugins.python.api.PythonVisitorContext;
 import org.sonar.plugins.python.api.symbols.Symbol;
 import org.sonar.plugins.python.api.tree.Tree;
 import org.sonar.python.checks.utils.PythonCheckVerifier;
 
-public class PycaEllipticCurveDeriveTest extends TestBase {
+class PycaEllipticCurveDeriveTest extends TestBase {
 
     @Test
-    public void test() {
+    void test() {
         PythonCheckVerifier.verify(
                 "src/test/files/rules/detection/asymmetric/EllipticCurve/PycaEllipticCurveDeriveTestFile.py",
                 this);

--- a/python/src/test/java/com/ibm/plugin/rules/detection/asymmetric/EllipticCurve/PycaEllipticCurveKeyExchangeTest.java
+++ b/python/src/test/java/com/ibm/plugin/rules/detection/asymmetric/EllipticCurve/PycaEllipticCurveKeyExchangeTest.java
@@ -45,17 +45,17 @@ import com.ibm.mapper.model.functionality.KeyGeneration;
 import com.ibm.plugin.TestBase;
 import java.util.List;
 import javax.annotation.Nonnull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.plugins.python.api.PythonCheck;
 import org.sonar.plugins.python.api.PythonVisitorContext;
 import org.sonar.plugins.python.api.symbols.Symbol;
 import org.sonar.plugins.python.api.tree.Tree;
 import org.sonar.python.checks.utils.PythonCheckVerifier;
 
-public class PycaEllipticCurveKeyExchangeTest extends TestBase {
+class PycaEllipticCurveKeyExchangeTest extends TestBase {
 
     @Test
-    public void test() {
+    void test() {
         PythonCheckVerifier.verify(
                 "src/test/files/rules/detection/asymmetric/EllipticCurve/PycaEllipticCurveKeyExchangeTestFile.py",
                 this);

--- a/python/src/test/java/com/ibm/plugin/rules/detection/asymmetric/EllipticCurve/PycaEllipticCurveNumbersTest.java
+++ b/python/src/test/java/com/ibm/plugin/rules/detection/asymmetric/EllipticCurve/PycaEllipticCurveNumbersTest.java
@@ -25,18 +25,18 @@ import com.ibm.plugin.TestBase;
 import java.util.List;
 import javax.annotation.Nonnull;
 import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.plugins.python.api.PythonCheck;
 import org.sonar.plugins.python.api.PythonVisitorContext;
 import org.sonar.plugins.python.api.symbols.Symbol;
 import org.sonar.plugins.python.api.tree.Tree;
 import org.sonar.python.checks.utils.PythonCheckVerifier;
 
-public class PycaEllipticCurveNumbersTest extends TestBase {
+class PycaEllipticCurveNumbersTest extends TestBase {
 
     @Ignore("In this testcase the name of a var is resolved, but not teh actual value.")
     @Test
-    public void test() {
+    void test() {
         PythonCheckVerifier.verify(
                 "src/test/files/rules/detection/asymmetric/EllipticCurve/PycaEllipticCurveNumbersTestFile.py",
                 this);

--- a/python/src/test/java/com/ibm/plugin/rules/detection/asymmetric/EllipticCurve/PycaEllipticCurveSign2Test.java
+++ b/python/src/test/java/com/ibm/plugin/rules/detection/asymmetric/EllipticCurve/PycaEllipticCurveSign2Test.java
@@ -38,17 +38,17 @@ import com.ibm.mapper.model.functionality.Digest;
 import com.ibm.plugin.TestBase;
 import java.util.List;
 import javax.annotation.Nonnull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.plugins.python.api.PythonCheck;
 import org.sonar.plugins.python.api.PythonVisitorContext;
 import org.sonar.plugins.python.api.symbols.Symbol;
 import org.sonar.plugins.python.api.tree.Tree;
 import org.sonar.python.checks.utils.PythonCheckVerifier;
 
-public class PycaEllipticCurveSign2Test extends TestBase {
+class PycaEllipticCurveSign2Test extends TestBase {
 
     @Test
-    public void test() {
+    void test() {
         PythonCheckVerifier.verify(
                 "src/test/files/rules/detection/asymmetric/EllipticCurve/PycaEllipticCurveSign2TestFile.py",
                 this);

--- a/python/src/test/java/com/ibm/plugin/rules/detection/asymmetric/EllipticCurve/PycaEllipticCurveSignTest.java
+++ b/python/src/test/java/com/ibm/plugin/rules/detection/asymmetric/EllipticCurve/PycaEllipticCurveSignTest.java
@@ -42,17 +42,17 @@ import com.ibm.mapper.model.functionality.Sign;
 import com.ibm.plugin.TestBase;
 import java.util.List;
 import javax.annotation.Nonnull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.plugins.python.api.PythonCheck;
 import org.sonar.plugins.python.api.PythonVisitorContext;
 import org.sonar.plugins.python.api.symbols.Symbol;
 import org.sonar.plugins.python.api.tree.Tree;
 import org.sonar.python.checks.utils.PythonCheckVerifier;
 
-public class PycaEllipticCurveSignTest extends TestBase {
+class PycaEllipticCurveSignTest extends TestBase {
 
     @Test
-    public void test() {
+    void test() {
         PythonCheckVerifier.verify(
                 "src/test/files/rules/detection/asymmetric/EllipticCurve/PycaEllipticCurveSignTestFile.py",
                 this);

--- a/python/src/test/java/com/ibm/plugin/rules/detection/asymmetric/EllipticCurve/PycaEllipticCurveVerifyTest.java
+++ b/python/src/test/java/com/ibm/plugin/rules/detection/asymmetric/EllipticCurve/PycaEllipticCurveVerifyTest.java
@@ -24,22 +24,22 @@ import com.ibm.mapper.model.INode;
 import com.ibm.plugin.TestBase;
 import java.util.List;
 import javax.annotation.Nonnull;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.sonar.plugins.python.api.PythonCheck;
 import org.sonar.plugins.python.api.PythonVisitorContext;
 import org.sonar.plugins.python.api.symbols.Symbol;
 import org.sonar.plugins.python.api.tree.Tree;
 import org.sonar.python.checks.utils.PythonCheckVerifier;
 
-public class PycaEllipticCurveVerifyTest extends TestBase {
+class PycaEllipticCurveVerifyTest extends TestBase {
 
     // junit4
-    @Ignore(
+    @Disabled(
             "Reenable once we have an approach to detect `verify` (either make it an entry\n"
                     + "point, or better handle file imports for depending detection rule)")
     @Test
-    public void test() {
+    void test() {
         PythonCheckVerifier.verify(
                 "src/test/files/rules/detection/asymmetric/EllipticCurve/PycaEllipticCurveVerifyTestFile.py",
                 this);

--- a/python/src/test/java/com/ibm/plugin/rules/detection/asymmetric/RSA/PycaRSADecryptTest.java
+++ b/python/src/test/java/com/ibm/plugin/rules/detection/asymmetric/RSA/PycaRSADecryptTest.java
@@ -46,17 +46,17 @@ import com.ibm.mapper.model.functionality.KeyGeneration;
 import com.ibm.plugin.TestBase;
 import java.util.List;
 import javax.annotation.Nonnull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.plugins.python.api.PythonCheck;
 import org.sonar.plugins.python.api.PythonVisitorContext;
 import org.sonar.plugins.python.api.symbols.Symbol;
 import org.sonar.plugins.python.api.tree.Tree;
 import org.sonar.python.checks.utils.PythonCheckVerifier;
 
-public class PycaRSADecryptTest extends TestBase {
+class PycaRSADecryptTest extends TestBase {
 
     @Test
-    public void test() {
+    void test() {
         PythonCheckVerifier.verify(
                 "src/test/files/rules/detection/asymmetric/RSA/PycaRSADecryptTestFile.py", this);
     }

--- a/python/src/test/java/com/ibm/plugin/rules/detection/asymmetric/RSA/PycaRSANumbersTest.java
+++ b/python/src/test/java/com/ibm/plugin/rules/detection/asymmetric/RSA/PycaRSANumbersTest.java
@@ -35,17 +35,17 @@ import com.ibm.mapper.model.functionality.KeyGeneration;
 import com.ibm.plugin.TestBase;
 import java.util.List;
 import javax.annotation.Nonnull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.plugins.python.api.PythonCheck;
 import org.sonar.plugins.python.api.PythonVisitorContext;
 import org.sonar.plugins.python.api.symbols.Symbol;
 import org.sonar.plugins.python.api.tree.Tree;
 import org.sonar.python.checks.utils.PythonCheckVerifier;
 
-public class PycaRSANumbersTest extends TestBase {
+class PycaRSANumbersTest extends TestBase {
 
     @Test
-    public void test() {
+    void test() {
         PythonCheckVerifier.verify(
                 "src/test/files/rules/detection/asymmetric/RSA/PycaRSANumbersTestFile.py", this);
     }

--- a/python/src/test/java/com/ibm/plugin/rules/detection/asymmetric/RSA/PycaRSASign1Test.java
+++ b/python/src/test/java/com/ibm/plugin/rules/detection/asymmetric/RSA/PycaRSASign1Test.java
@@ -44,17 +44,17 @@ import com.ibm.mapper.model.functionality.Sign;
 import com.ibm.plugin.TestBase;
 import java.util.List;
 import javax.annotation.Nonnull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.plugins.python.api.PythonCheck;
 import org.sonar.plugins.python.api.PythonVisitorContext;
 import org.sonar.plugins.python.api.symbols.Symbol;
 import org.sonar.plugins.python.api.tree.Tree;
 import org.sonar.python.checks.utils.PythonCheckVerifier;
 
-public class PycaRSASign1Test extends TestBase {
+class PycaRSASign1Test extends TestBase {
 
     @Test
-    public void test() {
+    void test() {
         PythonCheckVerifier.verify(
                 "src/test/files/rules/detection/asymmetric/RSA/PycaRSASign1TestFile.py", this);
     }

--- a/python/src/test/java/com/ibm/plugin/rules/detection/asymmetric/RSA/PycaRSASign2Test.java
+++ b/python/src/test/java/com/ibm/plugin/rules/detection/asymmetric/RSA/PycaRSASign2Test.java
@@ -43,17 +43,17 @@ import com.ibm.mapper.model.functionality.Sign;
 import com.ibm.plugin.TestBase;
 import java.util.List;
 import javax.annotation.Nonnull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.plugins.python.api.PythonCheck;
 import org.sonar.plugins.python.api.PythonVisitorContext;
 import org.sonar.plugins.python.api.symbols.Symbol;
 import org.sonar.plugins.python.api.tree.Tree;
 import org.sonar.python.checks.utils.PythonCheckVerifier;
 
-public class PycaRSASign2Test extends TestBase {
+class PycaRSASign2Test extends TestBase {
 
     @Test
-    public void test() {
+    void test() {
         PythonCheckVerifier.verify(
                 "src/test/files/rules/detection/asymmetric/RSA/PycaRSASign2TestFile.py", this);
     }

--- a/python/src/test/java/com/ibm/plugin/rules/detection/fernet/PycaFernetDecryptTest.java
+++ b/python/src/test/java/com/ibm/plugin/rules/detection/fernet/PycaFernetDecryptTest.java
@@ -46,17 +46,17 @@ import com.ibm.mapper.model.functionality.Tag;
 import com.ibm.plugin.TestBase;
 import java.util.List;
 import javax.annotation.Nonnull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.plugins.python.api.PythonCheck;
 import org.sonar.plugins.python.api.PythonVisitorContext;
 import org.sonar.plugins.python.api.symbols.Symbol;
 import org.sonar.plugins.python.api.tree.Tree;
 import org.sonar.python.checks.utils.PythonCheckVerifier;
 
-public class PycaFernetDecryptTest extends TestBase {
+class PycaFernetDecryptTest extends TestBase {
 
     @Test
-    public void test() {
+    void test() {
         PythonCheckVerifier.verify(
                 "src/test/files/rules/detection/fernet/PycaFernetDecryptTestFile.py", this);
     }

--- a/python/src/test/java/com/ibm/plugin/rules/detection/fernet/PycaFernetEncryptTest.java
+++ b/python/src/test/java/com/ibm/plugin/rules/detection/fernet/PycaFernetEncryptTest.java
@@ -46,17 +46,17 @@ import com.ibm.mapper.model.functionality.Tag;
 import com.ibm.plugin.TestBase;
 import java.util.List;
 import javax.annotation.Nonnull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.plugins.python.api.PythonCheck;
 import org.sonar.plugins.python.api.PythonVisitorContext;
 import org.sonar.plugins.python.api.symbols.Symbol;
 import org.sonar.plugins.python.api.tree.Tree;
 import org.sonar.python.checks.utils.PythonCheckVerifier;
 
-public class PycaFernetEncryptTest extends TestBase {
+class PycaFernetEncryptTest extends TestBase {
 
     @Test
-    public void test() {
+    void test() {
         PythonCheckVerifier.verify(
                 "src/test/files/rules/detection/fernet/PycaFernetEncryptTestFile.py", this);
     }

--- a/python/src/test/java/com/ibm/plugin/rules/detection/fernet/PycaMultiFernetTest.java
+++ b/python/src/test/java/com/ibm/plugin/rules/detection/fernet/PycaMultiFernetTest.java
@@ -47,17 +47,17 @@ import com.ibm.mapper.model.functionality.Tag;
 import com.ibm.plugin.TestBase;
 import java.util.List;
 import javax.annotation.Nonnull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.plugins.python.api.PythonCheck;
 import org.sonar.plugins.python.api.PythonVisitorContext;
 import org.sonar.plugins.python.api.symbols.Symbol;
 import org.sonar.plugins.python.api.tree.Tree;
 import org.sonar.python.checks.utils.PythonCheckVerifier;
 
-public class PycaMultiFernetTest extends TestBase {
+class PycaMultiFernetTest extends TestBase {
 
     @Test
-    public void test() {
+    void test() {
         PythonCheckVerifier.verify(
                 "src/test/files/rules/detection/fernet/PycaMultiFernetTestFile.py", this);
     }

--- a/python/src/test/java/com/ibm/plugin/rules/detection/kdf/PycaConcatKDFHMACTest.java
+++ b/python/src/test/java/com/ibm/plugin/rules/detection/kdf/PycaConcatKDFHMACTest.java
@@ -38,17 +38,17 @@ import com.ibm.mapper.model.functionality.KeyDerivation;
 import com.ibm.plugin.TestBase;
 import java.util.List;
 import javax.annotation.Nonnull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.plugins.python.api.PythonCheck;
 import org.sonar.plugins.python.api.PythonVisitorContext;
 import org.sonar.plugins.python.api.symbols.Symbol;
 import org.sonar.plugins.python.api.tree.Tree;
 import org.sonar.python.checks.utils.PythonCheckVerifier;
 
-public class PycaConcatKDFHMACTest extends TestBase {
+class PycaConcatKDFHMACTest extends TestBase {
 
     @Test
-    public void test() {
+    void test() {
         PythonCheckVerifier.verify(
                 "src/test/files/rules/detection/kdf/PycaConcatKDFHMACTestFile.py", this);
     }

--- a/python/src/test/java/com/ibm/plugin/rules/detection/kdf/PycaConcatKDFHashTest.java
+++ b/python/src/test/java/com/ibm/plugin/rules/detection/kdf/PycaConcatKDFHashTest.java
@@ -38,16 +38,16 @@ import com.ibm.mapper.model.functionality.KeyDerivation;
 import com.ibm.plugin.TestBase;
 import java.util.List;
 import javax.annotation.Nonnull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.plugins.python.api.PythonCheck;
 import org.sonar.plugins.python.api.PythonVisitorContext;
 import org.sonar.plugins.python.api.symbols.Symbol;
 import org.sonar.plugins.python.api.tree.Tree;
 import org.sonar.python.checks.utils.PythonCheckVerifier;
 
-public class PycaConcatKDFHashTest extends TestBase {
+class PycaConcatKDFHashTest extends TestBase {
     @Test
-    public void test() {
+    void test() {
         PythonCheckVerifier.verify(
                 "src/test/files/rules/detection/kdf/PycaConcatKDFHashTestFile.py", this);
     }

--- a/python/src/test/java/com/ibm/plugin/rules/detection/kdf/PycaHKDFExpandTest.java
+++ b/python/src/test/java/com/ibm/plugin/rules/detection/kdf/PycaHKDFExpandTest.java
@@ -38,17 +38,17 @@ import com.ibm.mapper.model.functionality.KeyDerivation;
 import com.ibm.plugin.TestBase;
 import java.util.List;
 import javax.annotation.Nonnull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.plugins.python.api.PythonCheck;
 import org.sonar.plugins.python.api.PythonVisitorContext;
 import org.sonar.plugins.python.api.symbols.Symbol;
 import org.sonar.plugins.python.api.tree.Tree;
 import org.sonar.python.checks.utils.PythonCheckVerifier;
 
-public class PycaHKDFExpandTest extends TestBase {
+class PycaHKDFExpandTest extends TestBase {
 
     @Test
-    public void test() {
+    void test() {
         PythonCheckVerifier.verify(
                 "src/test/files/rules/detection/kdf/PycaHKDFExpandTestFile.py", this);
     }

--- a/python/src/test/java/com/ibm/plugin/rules/detection/kdf/PycaHKDFTest.java
+++ b/python/src/test/java/com/ibm/plugin/rules/detection/kdf/PycaHKDFTest.java
@@ -38,17 +38,17 @@ import com.ibm.mapper.model.functionality.KeyDerivation;
 import com.ibm.plugin.TestBase;
 import java.util.List;
 import javax.annotation.Nonnull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.plugins.python.api.PythonCheck;
 import org.sonar.plugins.python.api.PythonVisitorContext;
 import org.sonar.plugins.python.api.symbols.Symbol;
 import org.sonar.plugins.python.api.tree.Tree;
 import org.sonar.python.checks.utils.PythonCheckVerifier;
 
-public class PycaHKDFTest extends TestBase {
+class PycaHKDFTest extends TestBase {
 
     @Test
-    public void test() {
+    void test() {
         PythonCheckVerifier.verify("src/test/files/rules/detection/kdf/PycaHKDFTestFile.py", this);
     }
 

--- a/python/src/test/java/com/ibm/plugin/rules/detection/kdf/PycaKBKDFCMACTest.java
+++ b/python/src/test/java/com/ibm/plugin/rules/detection/kdf/PycaKBKDFCMACTest.java
@@ -38,17 +38,17 @@ import com.ibm.mapper.model.functionality.Tag;
 import com.ibm.plugin.TestBase;
 import java.util.List;
 import javax.annotation.Nonnull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.plugins.python.api.PythonCheck;
 import org.sonar.plugins.python.api.PythonVisitorContext;
 import org.sonar.plugins.python.api.symbols.Symbol;
 import org.sonar.plugins.python.api.tree.Tree;
 import org.sonar.python.checks.utils.PythonCheckVerifier;
 
-public class PycaKBKDFCMACTest extends TestBase {
+class PycaKBKDFCMACTest extends TestBase {
 
     @Test
-    public void test() {
+    void test() {
         PythonCheckVerifier.verify(
                 "src/test/files/rules/detection/kdf/PycaKBKDFCMACTestFile.py", this);
     }

--- a/python/src/test/java/com/ibm/plugin/rules/detection/kdf/PycaKBKDFHMACTest.java
+++ b/python/src/test/java/com/ibm/plugin/rules/detection/kdf/PycaKBKDFHMACTest.java
@@ -38,20 +38,19 @@ import com.ibm.mapper.model.functionality.Digest;
 import com.ibm.mapper.model.functionality.KeyDerivation;
 import com.ibm.mapper.model.functionality.Tag;
 import com.ibm.plugin.TestBase;
-import com.ibm.plugin.utils.GenerateAssertsHelper;
 import java.util.List;
 import javax.annotation.Nonnull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.plugins.python.api.PythonCheck;
 import org.sonar.plugins.python.api.PythonVisitorContext;
 import org.sonar.plugins.python.api.symbols.Symbol;
 import org.sonar.plugins.python.api.tree.Tree;
 import org.sonar.python.checks.utils.PythonCheckVerifier;
 
-public class PycaKBKDFHMACTest extends TestBase {
+class PycaKBKDFHMACTest extends TestBase {
 
     @Test
-    public void test() {
+    void test() {
         PythonCheckVerifier.verify(
                 "src/test/files/rules/detection/kdf/PycaKBKDFHMACTestFile.py", this);
     }
@@ -61,7 +60,6 @@ public class PycaKBKDFHMACTest extends TestBase {
             int findingId,
             @Nonnull DetectionStore<PythonCheck, Tree, Symbol, PythonVisitorContext> detectionStore,
             @Nonnull List<INode> nodes) {
-        GenerateAssertsHelper.generate(detectionStore, nodes);
         /*
          * Detection Store
          */

--- a/python/src/test/java/com/ibm/plugin/rules/detection/kdf/PycaPBKDF2Test.java
+++ b/python/src/test/java/com/ibm/plugin/rules/detection/kdf/PycaPBKDF2Test.java
@@ -39,17 +39,17 @@ import com.ibm.mapper.model.functionality.KeyDerivation;
 import com.ibm.plugin.TestBase;
 import java.util.List;
 import javax.annotation.Nonnull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.plugins.python.api.PythonCheck;
 import org.sonar.plugins.python.api.PythonVisitorContext;
 import org.sonar.plugins.python.api.symbols.Symbol;
 import org.sonar.plugins.python.api.tree.Tree;
 import org.sonar.python.checks.utils.PythonCheckVerifier;
 
-public class PycaPBKDF2Test extends TestBase {
+class PycaPBKDF2Test extends TestBase {
 
     @Test
-    public void test() {
+    void test() {
         PythonCheckVerifier.verify(
                 "src/test/files/rules/detection/kdf/PycaPBKDF2TestFile.py", this);
     }

--- a/python/src/test/java/com/ibm/plugin/rules/detection/kdf/PycaScryptTest.java
+++ b/python/src/test/java/com/ibm/plugin/rules/detection/kdf/PycaScryptTest.java
@@ -33,17 +33,17 @@ import com.ibm.mapper.model.functionality.KeyDerivation;
 import com.ibm.plugin.TestBase;
 import java.util.List;
 import javax.annotation.Nonnull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.plugins.python.api.PythonCheck;
 import org.sonar.plugins.python.api.PythonVisitorContext;
 import org.sonar.plugins.python.api.symbols.Symbol;
 import org.sonar.plugins.python.api.tree.Tree;
 import org.sonar.python.checks.utils.PythonCheckVerifier;
 
-public class PycaScryptTest extends TestBase {
+class PycaScryptTest extends TestBase {
 
     @Test
-    public void test() {
+    void test() {
         PythonCheckVerifier.verify(
                 "src/test/files/rules/detection/kdf/PycaScryptTestFile.py", this);
     }

--- a/python/src/test/java/com/ibm/plugin/rules/detection/kdf/PycaX963KDFTest.java
+++ b/python/src/test/java/com/ibm/plugin/rules/detection/kdf/PycaX963KDFTest.java
@@ -38,17 +38,17 @@ import com.ibm.mapper.model.functionality.KeyDerivation;
 import com.ibm.plugin.TestBase;
 import java.util.List;
 import javax.annotation.Nonnull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.plugins.python.api.PythonCheck;
 import org.sonar.plugins.python.api.PythonVisitorContext;
 import org.sonar.plugins.python.api.symbols.Symbol;
 import org.sonar.plugins.python.api.tree.Tree;
 import org.sonar.python.checks.utils.PythonCheckVerifier;
 
-public class PycaX963KDFTest extends TestBase {
+class PycaX963KDFTest extends TestBase {
 
     @Test
-    public void test() {
+    void test() {
         PythonCheckVerifier.verify(
                 "src/test/files/rules/detection/kdf/PycaX963KDFTestFile.py", this);
     }

--- a/python/src/test/java/com/ibm/plugin/rules/detection/keyagreement/PycaKeyAgreementTest.java
+++ b/python/src/test/java/com/ibm/plugin/rules/detection/keyagreement/PycaKeyAgreementTest.java
@@ -33,17 +33,17 @@ import com.ibm.mapper.model.functionality.KeyGeneration;
 import com.ibm.plugin.TestBase;
 import java.util.List;
 import javax.annotation.Nonnull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.plugins.python.api.PythonCheck;
 import org.sonar.plugins.python.api.PythonVisitorContext;
 import org.sonar.plugins.python.api.symbols.Symbol;
 import org.sonar.plugins.python.api.tree.Tree;
 import org.sonar.python.checks.utils.PythonCheckVerifier;
 
-public class PycaKeyAgreementTest extends TestBase {
+class PycaKeyAgreementTest extends TestBase {
 
     @Test
-    public void test() {
+    void test() {
         PythonCheckVerifier.verify(
                 "src/test/files/rules/detection/keyagreement/PycaKeyAgreementTestFile.py", this);
     }

--- a/python/src/test/java/com/ibm/plugin/rules/detection/mac/PycaCMACTest.java
+++ b/python/src/test/java/com/ibm/plugin/rules/detection/mac/PycaCMACTest.java
@@ -34,17 +34,17 @@ import com.ibm.mapper.model.functionality.Tag;
 import com.ibm.plugin.TestBase;
 import java.util.List;
 import javax.annotation.Nonnull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.plugins.python.api.PythonCheck;
 import org.sonar.plugins.python.api.PythonVisitorContext;
 import org.sonar.plugins.python.api.symbols.Symbol;
 import org.sonar.plugins.python.api.tree.Tree;
 import org.sonar.python.checks.utils.PythonCheckVerifier;
 
-public class PycaCMACTest extends TestBase {
+class PycaCMACTest extends TestBase {
 
     @Test
-    public void test() {
+    void test() {
         PythonCheckVerifier.verify("src/test/files/rules/detection/mac/PycaCMACTestFile.py", this);
     }
 

--- a/python/src/test/java/com/ibm/plugin/rules/detection/mac/PycaHMACTest.java
+++ b/python/src/test/java/com/ibm/plugin/rules/detection/mac/PycaHMACTest.java
@@ -36,17 +36,17 @@ import com.ibm.mapper.model.functionality.Tag;
 import com.ibm.plugin.TestBase;
 import java.util.List;
 import javax.annotation.Nonnull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.plugins.python.api.PythonCheck;
 import org.sonar.plugins.python.api.PythonVisitorContext;
 import org.sonar.plugins.python.api.symbols.Symbol;
 import org.sonar.plugins.python.api.tree.Tree;
 import org.sonar.python.checks.utils.PythonCheckVerifier;
 
-public class PycaHMACTest extends TestBase {
+class PycaHMACTest extends TestBase {
 
     @Test
-    public void test() {
+    void test() {
         PythonCheckVerifier.verify("src/test/files/rules/detection/mac/PycaHMACTestFile.py", this);
     }
 

--- a/python/src/test/java/com/ibm/plugin/rules/detection/mac/PycaPoly1305Test.java
+++ b/python/src/test/java/com/ibm/plugin/rules/detection/mac/PycaPoly1305Test.java
@@ -33,17 +33,17 @@ import com.ibm.mapper.model.functionality.Tag;
 import com.ibm.plugin.TestBase;
 import java.util.List;
 import javax.annotation.Nonnull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.plugins.python.api.PythonCheck;
 import org.sonar.plugins.python.api.PythonVisitorContext;
 import org.sonar.plugins.python.api.symbols.Symbol;
 import org.sonar.plugins.python.api.tree.Tree;
 import org.sonar.python.checks.utils.PythonCheckVerifier;
 
-public class PycaPoly1305Test extends TestBase {
+class PycaPoly1305Test extends TestBase {
 
     @Test
-    public void test() {
+    void test() {
         PythonCheckVerifier.verify(
                 "src/test/files/rules/detection/mac/PycaPoly1305TestFile.py", this);
     }

--- a/python/src/test/java/com/ibm/plugin/rules/detection/padding/PycaPaddingTest.java
+++ b/python/src/test/java/com/ibm/plugin/rules/detection/padding/PycaPaddingTest.java
@@ -34,17 +34,17 @@ import com.ibm.mapper.model.Padding;
 import com.ibm.plugin.TestBase;
 import java.util.List;
 import javax.annotation.Nonnull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.plugins.python.api.PythonCheck;
 import org.sonar.plugins.python.api.PythonVisitorContext;
 import org.sonar.plugins.python.api.symbols.Symbol;
 import org.sonar.plugins.python.api.tree.Tree;
 import org.sonar.python.checks.utils.PythonCheckVerifier;
 
-public class PycaPaddingTest extends TestBase {
+class PycaPaddingTest extends TestBase {
 
     @Test
-    public void test() {
+    void test() {
         PythonCheckVerifier.verify(
                 "src/test/files/rules/detection/padding/PycaPaddingTestFile.py", this);
     }

--- a/python/src/test/java/com/ibm/plugin/rules/detection/symmetric/PycaCipher1Test.java
+++ b/python/src/test/java/com/ibm/plugin/rules/detection/symmetric/PycaCipher1Test.java
@@ -38,17 +38,17 @@ import com.ibm.mapper.model.functionality.Encrypt;
 import com.ibm.plugin.TestBase;
 import java.util.List;
 import javax.annotation.Nonnull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.plugins.python.api.PythonCheck;
 import org.sonar.plugins.python.api.PythonVisitorContext;
 import org.sonar.plugins.python.api.symbols.Symbol;
 import org.sonar.plugins.python.api.tree.Tree;
 import org.sonar.python.checks.utils.PythonCheckVerifier;
 
-public class PycaCipher1Test extends TestBase {
+class PycaCipher1Test extends TestBase {
 
     @Test
-    public void test() {
+    void test() {
         PythonCheckVerifier.verify(
                 "src/test/files/rules/detection/symmetric/PycaCipher1TestFile.py", this);
     }

--- a/python/src/test/java/com/ibm/plugin/rules/detection/symmetric/PycaCipher2Test.java
+++ b/python/src/test/java/com/ibm/plugin/rules/detection/symmetric/PycaCipher2Test.java
@@ -33,17 +33,17 @@ import com.ibm.mapper.model.functionality.Encrypt;
 import com.ibm.plugin.TestBase;
 import java.util.List;
 import javax.annotation.Nonnull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.plugins.python.api.PythonCheck;
 import org.sonar.plugins.python.api.PythonVisitorContext;
 import org.sonar.plugins.python.api.symbols.Symbol;
 import org.sonar.plugins.python.api.tree.Tree;
 import org.sonar.python.checks.utils.PythonCheckVerifier;
 
-public class PycaCipher2Test extends TestBase {
+class PycaCipher2Test extends TestBase {
 
     @Test
-    public void test() {
+    void test() {
         PythonCheckVerifier.verify(
                 "src/test/files/rules/detection/symmetric/PycaCipher2TestFile.py", this);
     }

--- a/python/src/test/java/com/ibm/plugin/rules/detection/wrapping/PycaWrappingTest.java
+++ b/python/src/test/java/com/ibm/plugin/rules/detection/wrapping/PycaWrappingTest.java
@@ -32,17 +32,17 @@ import com.ibm.mapper.model.functionality.Encapsulate;
 import com.ibm.plugin.TestBase;
 import java.util.List;
 import javax.annotation.Nonnull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.plugins.python.api.PythonCheck;
 import org.sonar.plugins.python.api.PythonVisitorContext;
 import org.sonar.plugins.python.api.symbols.Symbol;
 import org.sonar.plugins.python.api.tree.Tree;
 import org.sonar.python.checks.utils.PythonCheckVerifier;
 
-public class PycaWrappingTest extends TestBase {
+class PycaWrappingTest extends TestBase {
 
     @Test
-    public void test() {
+    void test() {
         PythonCheckVerifier.verify(
                 "src/test/files/rules/detection/wrapping/PycaWrappingTestFile.py", this);
     }

--- a/python/src/test/java/com/ibm/plugin/rules/detection/wrapping/PycaWrappingWithPaddingTest.java
+++ b/python/src/test/java/com/ibm/plugin/rules/detection/wrapping/PycaWrappingWithPaddingTest.java
@@ -32,17 +32,17 @@ import com.ibm.mapper.model.functionality.Encapsulate;
 import com.ibm.plugin.TestBase;
 import java.util.List;
 import javax.annotation.Nonnull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.plugins.python.api.PythonCheck;
 import org.sonar.plugins.python.api.PythonVisitorContext;
 import org.sonar.plugins.python.api.symbols.Symbol;
 import org.sonar.plugins.python.api.tree.Tree;
 import org.sonar.python.checks.utils.PythonCheckVerifier;
 
-public class PycaWrappingWithPaddingTest extends TestBase {
+class PycaWrappingWithPaddingTest extends TestBase {
 
     @Test
-    public void test() {
+    void test() {
         PythonCheckVerifier.verify(
                 "src/test/files/rules/detection/wrapping/PycaWrappingWithPaddingTestFile.py", this);
     }

--- a/python/src/test/java/com/ibm/plugin/rules/resolve/ResolveAliasImportTest.java
+++ b/python/src/test/java/com/ibm/plugin/rules/resolve/ResolveAliasImportTest.java
@@ -24,14 +24,14 @@ import com.ibm.mapper.model.INode;
 import com.ibm.plugin.TestBase;
 import java.util.List;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.plugins.python.api.PythonCheck;
 import org.sonar.plugins.python.api.PythonVisitorContext;
 import org.sonar.plugins.python.api.symbols.Symbol;
 import org.sonar.plugins.python.api.tree.Tree;
 import org.sonar.python.checks.utils.PythonCheckVerifier;
 
-public class ResolveAliasImportTest extends TestBase {
+class ResolveAliasImportTest extends TestBase {
     // This Test class structure allows testing a single class of rules instead of all rules defined
     // in PythonDetectionRules.
     // To do so, add `extends PythonBaseDetectionRule` and define a constructor using the rules you
@@ -51,7 +51,7 @@ public class ResolveAliasImportTest extends TestBase {
     }
 
     @Test
-    public void test() {
+    void test() {
         PythonCheckVerifier.verify(
                 "src/test/files/rules/resolve/ResolveAliasImportTestFile.py", this);
     }

--- a/python/src/test/java/com/ibm/plugin/rules/resolve/ResolveImportedStructTest.java
+++ b/python/src/test/java/com/ibm/plugin/rules/resolve/ResolveImportedStructTest.java
@@ -24,15 +24,15 @@ import com.ibm.mapper.model.INode;
 import com.ibm.plugin.TestBase;
 import java.util.List;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.sonar.plugins.python.api.PythonCheck;
 import org.sonar.plugins.python.api.PythonVisitorContext;
 import org.sonar.plugins.python.api.symbols.Symbol;
 import org.sonar.plugins.python.api.tree.Tree;
 import org.sonar.python.checks.utils.PythonCheckVerifier;
 
-public class ResolveImportedStructTest extends TestBase {
+class ResolveImportedStructTest extends TestBase {
     // This Test class structure allows testing a single class of rules instead of all rules defined
     // in PythonDetectionRules.
     // To do so, add `extends PythonBaseDetectionRule` and define a constructor using the rules you
@@ -51,9 +51,9 @@ public class ResolveImportedStructTest extends TestBase {
         // nothing
     }
 
-    @Ignore("feature not supported/implemented")
+    @Disabled("feature not supported/implemented")
     @Test
-    public void test() {
+    void test() {
         PythonCheckVerifier.verify(
                 List.of(
                         "src/test/files/rules/resolve/ResolveImportedStructTestFile.py",

--- a/python/src/test/java/com/ibm/plugin/rules/resolve/ResolveInnerFunctionCallTest.java
+++ b/python/src/test/java/com/ibm/plugin/rules/resolve/ResolveInnerFunctionCallTest.java
@@ -24,14 +24,14 @@ import com.ibm.mapper.model.INode;
 import com.ibm.plugin.TestBase;
 import java.util.List;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.plugins.python.api.PythonCheck;
 import org.sonar.plugins.python.api.PythonVisitorContext;
 import org.sonar.plugins.python.api.symbols.Symbol;
 import org.sonar.plugins.python.api.tree.Tree;
 import org.sonar.python.checks.utils.PythonCheckVerifier;
 
-public class ResolveInnerFunctionCallTest extends TestBase {
+class ResolveInnerFunctionCallTest extends TestBase {
     // This Test class structure allows testing a single class of rules instead of all rules defined
     // in PythonDetectionRules.
     // To do so, add `extends PythonBaseDetectionRule` and define a constructor using the rules you
@@ -51,7 +51,7 @@ public class ResolveInnerFunctionCallTest extends TestBase {
     }
 
     @Test
-    public void test() {
+    void test() {
         PythonCheckVerifier.verify(
                 "src/test/files/rules/resolve/ResolveInnerFunctionCallTestFile.py", this);
     }

--- a/python/src/test/java/com/ibm/plugin/rules/resolve/ResolveNameTypeAndValuesTest.java
+++ b/python/src/test/java/com/ibm/plugin/rules/resolve/ResolveNameTypeAndValuesTest.java
@@ -24,14 +24,14 @@ import com.ibm.mapper.model.INode;
 import com.ibm.plugin.TestBase;
 import java.util.List;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.plugins.python.api.PythonCheck;
 import org.sonar.plugins.python.api.PythonVisitorContext;
 import org.sonar.plugins.python.api.symbols.Symbol;
 import org.sonar.plugins.python.api.tree.Tree;
 import org.sonar.python.checks.utils.PythonCheckVerifier;
 
-public class ResolveNameTypeAndValuesTest extends TestBase {
+class ResolveNameTypeAndValuesTest extends TestBase {
     // This Test class structure allows testing a single class of rules instead of all rules defined
     // in PythonDetectionRules.
     // To do so, add `extends PythonBaseDetectionRule` and define a constructor using the rules you
@@ -50,7 +50,7 @@ public class ResolveNameTypeAndValuesTest extends TestBase {
     }
 
     @Test
-    public void test() {
+    void test() {
         PythonCheckVerifier.verify(
                 "src/test/files/rules/resolve/ResolveNameTypeAndValuesTestFile.py", this);
     }

--- a/python/src/test/java/com/ibm/plugin/rules/resolve/ResolveScopeValuesTest.java
+++ b/python/src/test/java/com/ibm/plugin/rules/resolve/ResolveScopeValuesTest.java
@@ -24,14 +24,14 @@ import com.ibm.mapper.model.INode;
 import com.ibm.plugin.TestBase;
 import java.util.List;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.plugins.python.api.PythonCheck;
 import org.sonar.plugins.python.api.PythonVisitorContext;
 import org.sonar.plugins.python.api.symbols.Symbol;
 import org.sonar.plugins.python.api.tree.Tree;
 import org.sonar.python.checks.utils.PythonCheckVerifier;
 
-public class ResolveScopeValuesTest extends TestBase {
+class ResolveScopeValuesTest extends TestBase {
     // This Test class structure allows testing a single class of rules instead of all rules defined
     // in PythonDetectionRules.
     // To do so, add `extends PythonBaseDetectionRule` and define a constructor using the rules you
@@ -50,7 +50,7 @@ public class ResolveScopeValuesTest extends TestBase {
     }
 
     @Test
-    public void test() {
+    void test() {
         PythonCheckVerifier.verify(
                 "src/test/files/rules/resolve/ResolveScopeValuesTestFile.py", this);
     }

--- a/python/src/test/java/com/ibm/plugin/rules/resolve/ResolveValuesWithHooksTest.java
+++ b/python/src/test/java/com/ibm/plugin/rules/resolve/ResolveValuesWithHooksTest.java
@@ -24,14 +24,14 @@ import com.ibm.mapper.model.INode;
 import com.ibm.plugin.TestBase;
 import java.util.List;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sonar.plugins.python.api.PythonCheck;
 import org.sonar.plugins.python.api.PythonVisitorContext;
 import org.sonar.plugins.python.api.symbols.Symbol;
 import org.sonar.plugins.python.api.tree.Tree;
 import org.sonar.python.checks.utils.PythonCheckVerifier;
 
-public class ResolveValuesWithHooksTest extends TestBase {
+class ResolveValuesWithHooksTest extends TestBase {
     // This Test class structure allows testing a single class of rules instead of all rules defined
     // in PythonDetectionRules.
     // To do so, add `extends PythonBaseDetectionRule` and define a constructor using the rules you
@@ -50,7 +50,7 @@ public class ResolveValuesWithHooksTest extends TestBase {
     }
 
     @Test
-    public void test() {
+    void test() {
         PythonCheckVerifier.verify(
                 "src/test/files/rules/resolve/ResolveValuesWithHooksTestFile.py", this);
     }


### PR DESCRIPTION
- Add a dependency to `junit-jupiter-engine` to fix how Python tests are executed
- Replace all `org.junit.Test` by `org.junit.jupiter.api.Test`