### PR TITLE
feat(csharp): add ML-KEM (FIPS 203) detection rules for .NET 10

### DIFF
--- a/csharp/src/main/java/com/ibm/plugin/rules/detection/CSharpDetectionRules.java
+++ b/csharp/src/main/java/com/ibm/plugin/rules/detection/CSharpDetectionRules.java
@@ -27,6 +27,7 @@ import com.ibm.plugin.rules.detection.dotnet.DotNetDSA;
 import com.ibm.plugin.rules.detection.dotnet.DotNetECDiffieHellman;
 import com.ibm.plugin.rules.detection.dotnet.DotNetECDsa;
 import com.ibm.plugin.rules.detection.dotnet.DotNetHMAC;
+import com.ibm.plugin.rules.detection.dotnet.DotNetMLKem;
 import com.ibm.plugin.rules.detection.dotnet.DotNetRC2;
 import com.ibm.plugin.rules.detection.dotnet.DotNetRSA;
 import com.ibm.plugin.rules.detection.dotnet.DotNetRfc2898DeriveBytes;
@@ -56,7 +57,8 @@ public final class CSharpDetectionRules {
                         DotNetDSA.rules().stream(),
                         DotNetSHA.rules().stream(),
                         DotNetHMAC.rules().stream(),
-                        DotNetRfc2898DeriveBytes.rules().stream())
+                        DotNetRfc2898DeriveBytes.rules().stream(),
+                        DotNetMLKem.rules().stream())
                 .flatMap(i -> i)
                 .toList();
     }

--- a/csharp/src/main/java/com/ibm/plugin/rules/detection/dotnet/DotNetMLKem.java
+++ b/csharp/src/main/java/com/ibm/plugin/rules/detection/dotnet/DotNetMLKem.java
@@ -19,6 +19,7 @@
  */
 package com.ibm.plugin.rules.detection.dotnet;
 
+import com.ibm.engine.detection.MethodMatcher;
 import com.ibm.engine.language.csharp.tree.CSharpTree;
 import com.ibm.engine.model.context.KeyContext;
 import com.ibm.engine.model.factory.ValueActionFactory;
@@ -52,18 +53,17 @@ public final class DotNetMLKem {
                 .forObjectTypes(className)
                 .forMethods("GenerateKey")
                 .shouldBeDetectedAs(new ValueActionFactory<>(value))
-                .withoutParameters()
+                .withMethodParameter(MethodMatcher.ANY)
                 .buildForContext(new KeyContext(Map.of("kind", "MLKEM")))
                 .inBundle(() -> "DotNet")
                 .withoutDependingDetectionRules();
     }
 
-    private static final IDetectionRule<CSharpTree> MLKEM_512 = mlKemRule("MLKem512", "MLKEM512");
+    private static final IDetectionRule<CSharpTree> MLKEM_512 = mlKemRule("MLKem", "MLKEM512");
 
-    private static final IDetectionRule<CSharpTree> MLKEM_768 = mlKemRule("MLKem768", "MLKEM768");
+    private static final IDetectionRule<CSharpTree> MLKEM_768 = mlKemRule("MLKem", "MLKEM768");
 
-    private static final IDetectionRule<CSharpTree> MLKEM_1024 =
-            mlKemRule("MLKem1024", "MLKEM1024");
+    private static final IDetectionRule<CSharpTree> MLKEM_1024 = mlKemRule("MLKem", "MLKEM1024");
 
     @Nonnull
     public static List<IDetectionRule<CSharpTree>> rules() {

--- a/csharp/src/main/java/com/ibm/plugin/rules/detection/dotnet/DotNetMLKem.java
+++ b/csharp/src/main/java/com/ibm/plugin/rules/detection/dotnet/DotNetMLKem.java
@@ -1,0 +1,72 @@
+/*
+ * Sonar Cryptography Plugin
+ * Copyright (C) 2024 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.plugin.rules.detection.dotnet;
+
+import com.ibm.engine.language.csharp.tree.CSharpTree;
+import com.ibm.engine.model.context.KeyContext;
+import com.ibm.engine.model.factory.ValueActionFactory;
+import com.ibm.engine.rule.IDetectionRule;
+import com.ibm.engine.rule.builder.DetectionRuleBuilder;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nonnull;
+
+/**
+ * Detection rules for ML-KEM (FIPS 203) in .NET 9+.
+ *
+ * <p>Detects key generation for all three parameter sets:
+ *
+ * <ul>
+ *   <li>{@code MLKem512.GenerateKey()}
+ *   <li>{@code MLKem768.GenerateKey()}
+ *   <li>{@code MLKem1024.GenerateKey()}
+ * </ul>
+ */
+@SuppressWarnings("java:S1192")
+public final class DotNetMLKem {
+
+    private DotNetMLKem() {
+        // nothing
+    }
+
+    private static IDetectionRule<CSharpTree> mlKemRule(String className, String value) {
+        return new DetectionRuleBuilder<CSharpTree>()
+                .createDetectionRule()
+                .forObjectTypes(className)
+                .forMethods("GenerateKey")
+                .shouldBeDetectedAs(new ValueActionFactory<>(value))
+                .withoutParameters()
+                .buildForContext(new KeyContext(Map.of("kind", "MLKEM")))
+                .inBundle(() -> "DotNet")
+                .withoutDependingDetectionRules();
+    }
+
+    private static final IDetectionRule<CSharpTree> MLKEM_512 = mlKemRule("MLKem512", "MLKEM512");
+
+    private static final IDetectionRule<CSharpTree> MLKEM_768 = mlKemRule("MLKem768", "MLKEM768");
+
+    private static final IDetectionRule<CSharpTree> MLKEM_1024 =
+            mlKemRule("MLKem1024", "MLKEM1024");
+
+    @Nonnull
+    public static List<IDetectionRule<CSharpTree>> rules() {
+        return List.of(MLKEM_512, MLKEM_768, MLKEM_1024);
+    }
+}

--- a/csharp/src/main/java/com/ibm/plugin/translation/translator/contexts/CSharpKeyContextTranslator.java
+++ b/csharp/src/main/java/com/ibm/plugin/translation/translator/contexts/CSharpKeyContextTranslator.java
@@ -32,6 +32,7 @@ import com.ibm.mapper.model.KeyLength;
 import com.ibm.mapper.model.algorithms.DSA;
 import com.ibm.mapper.model.algorithms.ECDH;
 import com.ibm.mapper.model.algorithms.ECDSA;
+import com.ibm.mapper.model.algorithms.MLKEM;
 import com.ibm.mapper.model.algorithms.PBKDF2;
 import com.ibm.mapper.model.algorithms.RSA;
 import com.ibm.mapper.utils.DetectionLocation;
@@ -57,6 +58,7 @@ public final class CSharpKeyContextTranslator implements IContextTranslation<CSh
                 case "ECDH" -> Optional.of(new ECDH(detectionLocation));
                 case "DSA" -> Optional.of(new DSA(detectionLocation));
                 case "KDF" -> Optional.of(new PBKDF2(detectionLocation));
+                case "MLKEM" -> Optional.of(new MLKEM(detectionLocation));
                 default -> Optional.empty();
             };
         } else if (value instanceof KeySize<?> keySize) {

--- a/csharp/src/test/files/rules/detection/dotnet/DotNetMLKemTestFile.cs
+++ b/csharp/src/test/files/rules/detection/dotnet/DotNetMLKemTestFile.cs
@@ -1,0 +1,19 @@
+using System.Security.Cryptography;
+
+public class DotNetMLKemTest
+{
+    public void TestMLKem512()
+    {
+        var key = MLKem512.GenerateKey(); // Noncompliant
+    }
+
+    public void TestMLKem768()
+    {
+        var key = MLKem768.GenerateKey(); // Noncompliant
+    }
+
+    public void TestMLKem1024()
+    {
+        var key = MLKem1024.GenerateKey(); // Noncompliant
+    }
+}

--- a/csharp/src/test/files/rules/detection/dotnet/DotNetMLKemTestFile.cs
+++ b/csharp/src/test/files/rules/detection/dotnet/DotNetMLKemTestFile.cs
@@ -4,16 +4,16 @@ public class DotNetMLKemTest
 {
     public void TestMLKem512()
     {
-        var key = MLKem512.GenerateKey(); // Noncompliant
+        var key = MLKem.GenerateKey(MLKemAlgorithm.MLKem512); // Noncompliant
     }
 
     public void TestMLKem768()
     {
-        var key = MLKem768.GenerateKey(); // Noncompliant
+        var key = MLKem.GenerateKey(MLKemAlgorithm.MLKem768); // Noncompliant
     }
 
     public void TestMLKem1024()
     {
-        var key = MLKem1024.GenerateKey(); // Noncompliant
+        var key = MLKem.GenerateKey(MLKemAlgorithm.MLKem1024); // Noncompliant
     }
 }

--- a/csharp/src/test/java/com/ibm/plugin/rules/detection/dotnet/DotNetMLKemTest.java
+++ b/csharp/src/test/java/com/ibm/plugin/rules/detection/dotnet/DotNetMLKemTest.java
@@ -1,0 +1,72 @@
+/*
+ * Sonar Cryptography Plugin
+ * Copyright (C) 2024 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.plugin.rules.detection.dotnet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ibm.engine.detection.DetectionStore;
+import com.ibm.engine.language.csharp.CSharpCheck;
+import com.ibm.engine.language.csharp.CSharpScanContext;
+import com.ibm.engine.language.csharp.CSharpSymbol;
+import com.ibm.engine.language.csharp.tree.CSharpTree;
+import com.ibm.engine.model.IValue;
+import com.ibm.engine.model.ValueAction;
+import com.ibm.engine.model.context.KeyContext;
+import com.ibm.mapper.model.INode;
+import com.ibm.mapper.model.KeyEncapsulationMechanism;
+import com.ibm.plugin.CSharpVerifier;
+import com.ibm.plugin.TestBase;
+import java.util.List;
+import javax.annotation.Nonnull;
+import org.junit.jupiter.api.Test;
+
+class DotNetMLKemTest extends TestBase {
+
+    @Test
+    void test() throws Exception {
+        CSharpVerifier.verify("rules/detection/dotnet/DotNetMLKemTestFile.cs", this);
+    }
+
+    @Override
+    public void asserts(
+            int findingId,
+            @Nonnull
+                    DetectionStore<CSharpCheck, CSharpTree, CSharpSymbol, CSharpScanContext>
+                            detectionStore,
+            @Nonnull List<INode> nodes) {
+
+        /*
+         * Detection Store
+         */
+        assertThat(detectionStore.getDetectionValues()).hasSize(1);
+        assertThat(detectionStore.getDetectionValueContext()).isInstanceOf(KeyContext.class);
+        IValue<CSharpTree> value = detectionStore.getDetectionValues().get(0);
+        assertThat(value).isInstanceOf(ValueAction.class);
+        assertThat(value.asString()).isIn("MLKEM512", "MLKEM768", "MLKEM1024");
+
+        /*
+         * Translation
+         */
+        assertThat(nodes).hasSize(1);
+        INode node = nodes.get(0);
+        assertThat(node.getKind()).isEqualTo(KeyEncapsulationMechanism.class);
+        assertThat(node.asString()).startsWith("ML-KEM");
+    }
+}


### PR DESCRIPTION
## Summary
Adds ML-KEM (FIPS 203) detection rules for .NET 10 System.Security.Cryptography.
Builds on top of #376 (C# initial support).

## Changes
- `DotNetMLKem.java`: detect `MLKem.GenerateKey(MLKemAlgorithm)`
- `DotNetMLKemTestFile.cs`: C# test file using correct .NET 10 API
- `DotNetMLKemTest.java`: unit test verifying detection and translation
- `CSharpDetectionRules.java`: registers DotNetMLKem in rule aggregator
- `CSharpKeyContextTranslator.java`: maps MLKEM kind to MLKEM model node

## Testing
- 20 tests pass (was 19 before)
- mvn spotless:check passes
- mvn -B clean package -pl csharp passes
<img width="1139" height="530" alt="Screenshot 2026-05-05 205328" src="https://github.com/user-attachments/assets/6dfb6cff-4ba1-477a-a9ce-6432ea47f4d5" />

## Planned follow-up
- MLKemCng, MLKemOpenSsl derived classes
- Encapsulate/Decapsulate as depending rules
- Import methods (ImportEncapsulationKey, ImportDecapsulationKey)