### PR TITLE
feat(pbes1): add OID mappings for PBES1 combinations

### DIFF
--- a/enricher/src/main/java/com/ibm/enricher/Enricher.java
+++ b/enricher/src/main/java/com/ibm/enricher/Enricher.java
@@ -26,6 +26,7 @@ import com.ibm.enricher.algorithm.DHEnricher;
 import com.ibm.enricher.algorithm.DSAEnricher;
 import com.ibm.enricher.algorithm.HMACEnricher;
 import com.ibm.enricher.algorithm.KEMEnricher;
+import com.ibm.enricher.algorithm.PBES1Enricher;
 import com.ibm.enricher.algorithm.PBKDF2Enricher;
 import com.ibm.enricher.algorithm.RSAEnricher;
 import com.ibm.enricher.algorithm.RSAoaepEnricher;
@@ -90,6 +91,7 @@ public class Enricher implements IEnricher {
                     new SHA3Enricher(),
                     new HMACEnricher(),
                     new PBKDF2Enricher(),
+                    new PBES1Enricher(),
                     new RSAssaPSSEnricher(),
                     new RSAoaepEnricher(),
                     new SignatureEnricher(),

--- a/enricher/src/main/java/com/ibm/enricher/algorithm/PBES1Enricher.java
+++ b/enricher/src/main/java/com/ibm/enricher/algorithm/PBES1Enricher.java
@@ -76,6 +76,7 @@ public class PBES1Enricher implements IEnricher {
             if (cipher instanceof RC4) {
                 if (keyLength == 128) return "1.2.840.113549.1.12.1.1";
                 if (keyLength == 40) return "1.2.840.113549.1.12.1.2";
+                // No PKCS#5 OID exists for SHA1+RC4 with other key lengths; null is intentional.
             }
             if (cipher instanceof TripleDES) {
                 if (keyLength == 192 || keyLength == 168) return "1.2.840.113549.1.12.1.3";

--- a/enricher/src/main/java/com/ibm/enricher/algorithm/PBES1Enricher.java
+++ b/enricher/src/main/java/com/ibm/enricher/algorithm/PBES1Enricher.java
@@ -1,0 +1,87 @@
+/*
+ * Sonar Cryptography Plugin
+ * Copyright (C) 2024 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.enricher.algorithm;
+
+import com.ibm.enricher.IEnricher;
+import com.ibm.mapper.model.Cipher;
+import com.ibm.mapper.model.INode;
+import com.ibm.mapper.model.KeyLength;
+import com.ibm.mapper.model.MessageDigest;
+import com.ibm.mapper.model.Oid;
+import com.ibm.mapper.model.PBES1;
+import com.ibm.mapper.model.algorithms.DES;
+import com.ibm.mapper.model.algorithms.MD2;
+import com.ibm.mapper.model.algorithms.MD5;
+import com.ibm.mapper.model.algorithms.RC2;
+import com.ibm.mapper.model.algorithms.RC4;
+import com.ibm.mapper.model.algorithms.SHA;
+import com.ibm.mapper.model.algorithms.TripleDES;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class PBES1Enricher implements IEnricher {
+
+    @Override
+    @Nonnull
+    public INode enrich(@Nonnull INode node) {
+        if (node instanceof PBES1 pbes1) {
+            final MessageDigest digest = pbes1.getDigest().orElse(null);
+            final Cipher cipher = pbes1.getCipher().orElse(null);
+
+            if (digest != null && cipher != null) {
+                final String oidValue = resolveOid(digest, cipher);
+                if (oidValue != null) {
+                    pbes1.put(new Oid(oidValue, pbes1.getDetectionContext()));
+                }
+            }
+        }
+        return node;
+    }
+
+    @Nullable private String resolveOid(@Nonnull MessageDigest digest, @Nonnull Cipher cipher) {
+        if (digest instanceof MD2) {
+            if (cipher instanceof DES) return "1.2.840.113549.1.5.1";
+            if (cipher instanceof RC2) return "1.2.840.113549.1.5.4";
+        } else if (digest instanceof MD5) {
+            if (cipher instanceof DES) return "1.2.840.113549.1.5.3";
+            if (cipher instanceof RC2) return "1.2.840.113549.1.5.6";
+        } else if (digest instanceof SHA) {
+            // PKCS#5
+            if (cipher instanceof DES) return "1.2.840.113549.1.5.10";
+
+            // PKCS#12
+            final int keyLength = cipher.getKeyLength().map(KeyLength::getValue).orElse(-1);
+            if (cipher instanceof RC2) {
+                if (keyLength == 128) return "1.2.840.113549.1.12.1.5";
+                if (keyLength == 40) return "1.2.840.113549.1.12.1.6";
+                return "1.2.840.113549.1.5.11"; // PKCS#5 default
+            }
+            if (cipher instanceof RC4) {
+                if (keyLength == 128) return "1.2.840.113549.1.12.1.1";
+                if (keyLength == 40) return "1.2.840.113549.1.12.1.2";
+            }
+            if (cipher instanceof TripleDES) {
+                if (keyLength == 192 || keyLength == 168) return "1.2.840.113549.1.12.1.3";
+                if (keyLength == 128 || keyLength == 112) return "1.2.840.113549.1.12.1.4";
+            }
+        }
+        return null;
+    }
+}

--- a/enricher/src/test/java/com/ibm/enricher/algorithm/PBES1EnricherTest.java
+++ b/enricher/src/test/java/com/ibm/enricher/algorithm/PBES1EnricherTest.java
@@ -1,0 +1,72 @@
+/*
+ * Sonar Cryptography Plugin
+ * Copyright (C) 2024 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.enricher.algorithm;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ibm.enricher.TestBase;
+import com.ibm.mapper.model.INode;
+import com.ibm.mapper.model.Oid;
+import com.ibm.mapper.model.PBES1;
+import com.ibm.mapper.model.algorithms.DES;
+import com.ibm.mapper.model.algorithms.MD5;
+import com.ibm.mapper.model.algorithms.SHA;
+import com.ibm.mapper.model.algorithms.TripleDES;
+import com.ibm.mapper.utils.DetectionLocation;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class PBES1EnricherTest extends TestBase {
+
+    @Test
+    void pkcs5() {
+        DetectionLocation testDetectionLocation =
+                new DetectionLocation("testfile", 1, 1, List.of("test"), () -> "Jca");
+        final PBES1 pbes1 =
+                new PBES1(new MD5(testDetectionLocation), new DES(testDetectionLocation));
+        this.logBefore(pbes1);
+
+        final PBES1Enricher pbes1Enricher = new PBES1Enricher();
+        final INode enriched = pbes1Enricher.enrich(pbes1);
+        this.logAfter(enriched);
+
+        assertThat(enriched.hasChildOfType(Oid.class)).isPresent();
+        assertThat(enriched.hasChildOfType(Oid.class).get().asString())
+                .isEqualTo("1.2.840.113549.1.5.3");
+    }
+
+    @Test
+    void pkcs12() {
+        DetectionLocation testDetectionLocation =
+                new DetectionLocation("testfile", 1, 1, List.of("test"), () -> "Jca");
+        final PBES1 pbes1 =
+                new PBES1(
+                        new SHA(testDetectionLocation), new TripleDES(192, testDetectionLocation));
+        this.logBefore(pbes1);
+
+        final PBES1Enricher pbes1Enricher = new PBES1Enricher();
+        final INode enriched = pbes1Enricher.enrich(pbes1);
+        this.logAfter(enriched);
+
+        assertThat(enriched.hasChildOfType(Oid.class)).isPresent();
+        assertThat(enriched.hasChildOfType(Oid.class).get().asString())
+                .isEqualTo("1.2.840.113549.1.12.1.3");
+    }
+}

--- a/enricher/src/test/java/com/ibm/enricher/algorithm/PBES1EnricherTest.java
+++ b/enricher/src/test/java/com/ibm/enricher/algorithm/PBES1EnricherTest.java
@@ -22,51 +22,103 @@ package com.ibm.enricher.algorithm;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.ibm.enricher.TestBase;
+import com.ibm.mapper.model.Cipher;
 import com.ibm.mapper.model.INode;
+import com.ibm.mapper.model.MessageDigest;
 import com.ibm.mapper.model.Oid;
 import com.ibm.mapper.model.PBES1;
 import com.ibm.mapper.model.algorithms.DES;
+import com.ibm.mapper.model.algorithms.MD2;
 import com.ibm.mapper.model.algorithms.MD5;
+import com.ibm.mapper.model.algorithms.RC2;
+import com.ibm.mapper.model.algorithms.RC4;
 import com.ibm.mapper.model.algorithms.SHA;
 import com.ibm.mapper.model.algorithms.TripleDES;
 import com.ibm.mapper.utils.DetectionLocation;
 import java.util.List;
-import org.junit.jupiter.api.Test;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class PBES1EnricherTest extends TestBase {
 
-    @Test
-    void pkcs5() {
-        DetectionLocation testDetectionLocation =
-                new DetectionLocation("testfile", 1, 1, List.of("test"), () -> "Jca");
-        final PBES1 pbes1 =
-                new PBES1(new MD5(testDetectionLocation), new DES(testDetectionLocation));
-        this.logBefore(pbes1);
+    private static final DetectionLocation LOC =
+            new DetectionLocation("testfile", 1, 1, List.of("test"), () -> "Jca");
 
-        final PBES1Enricher pbes1Enricher = new PBES1Enricher();
-        final INode enriched = pbes1Enricher.enrich(pbes1);
-        this.logAfter(enriched);
-
-        assertThat(enriched.hasChildOfType(Oid.class)).isPresent();
-        assertThat(enriched.hasChildOfType(Oid.class).get().asString())
-                .isEqualTo("1.2.840.113549.1.5.3");
+    static Stream<Arguments> oidTable() {
+        return Stream.of(
+                // PKCS#5
+                Arguments.of(
+                        Named.of("MD2+DES", pbes1(new MD2(LOC), new DES(LOC))),
+                        "1.2.840.113549.1.5.1"),
+                Arguments.of(
+                        Named.of("MD5+DES", pbes1(new MD5(LOC), new DES(LOC))),
+                        "1.2.840.113549.1.5.3"),
+                Arguments.of(
+                        Named.of("MD2+RC2", pbes1(new MD2(LOC), new RC2(LOC))),
+                        "1.2.840.113549.1.5.4"),
+                Arguments.of(
+                        Named.of("MD5+RC2", pbes1(new MD5(LOC), new RC2(LOC))),
+                        "1.2.840.113549.1.5.6"),
+                Arguments.of(
+                        Named.of("SHA+DES", pbes1(new SHA(LOC), new DES(LOC))),
+                        "1.2.840.113549.1.5.10"),
+                Arguments.of(
+                        Named.of("SHA+RC2(default)", pbes1(new SHA(LOC), new RC2(LOC))),
+                        "1.2.840.113549.1.5.11"),
+                // PKCS#12
+                Arguments.of(
+                        Named.of("SHA+RC4-128", pbes1(new SHA(LOC), new RC4(128, LOC))),
+                        "1.2.840.113549.1.12.1.1"),
+                Arguments.of(
+                        Named.of("SHA+RC4-40", pbes1(new SHA(LOC), new RC4(40, LOC))),
+                        "1.2.840.113549.1.12.1.2"),
+                Arguments.of(
+                        Named.of("SHA+3DES-192", pbes1(new SHA(LOC), new TripleDES(192, LOC))),
+                        "1.2.840.113549.1.12.1.3"),
+                Arguments.of(
+                        Named.of("SHA+3DES-168", pbes1(new SHA(LOC), new TripleDES(168, LOC))),
+                        "1.2.840.113549.1.12.1.3"),
+                Arguments.of(
+                        Named.of("SHA+3DES-128", pbes1(new SHA(LOC), new TripleDES(128, LOC))),
+                        "1.2.840.113549.1.12.1.4"),
+                Arguments.of(
+                        Named.of("SHA+3DES-112", pbes1(new SHA(LOC), new TripleDES(112, LOC))),
+                        "1.2.840.113549.1.12.1.4"),
+                Arguments.of(
+                        Named.of("SHA+RC2-128", pbes1(new SHA(LOC), new RC2(128, LOC))),
+                        "1.2.840.113549.1.12.1.5"),
+                Arguments.of(
+                        Named.of("SHA+RC2-40", pbes1(new SHA(LOC), new RC2(40, LOC))),
+                        "1.2.840.113549.1.12.1.6"));
     }
 
-    @Test
-    void pkcs12() {
-        DetectionLocation testDetectionLocation =
-                new DetectionLocation("testfile", 1, 1, List.of("test"), () -> "Jca");
-        final PBES1 pbes1 =
-                new PBES1(
-                        new SHA(testDetectionLocation), new TripleDES(192, testDetectionLocation));
-        this.logBefore(pbes1);
-
-        final PBES1Enricher pbes1Enricher = new PBES1Enricher();
-        final INode enriched = pbes1Enricher.enrich(pbes1);
-        this.logAfter(enriched);
+    @ParameterizedTest
+    @MethodSource("oidTable")
+    void resolvesOid(PBES1 pbes1, String expectedOid) {
+        final INode enriched = new PBES1Enricher().enrich(pbes1);
 
         assertThat(enriched.hasChildOfType(Oid.class)).isPresent();
-        assertThat(enriched.hasChildOfType(Oid.class).get().asString())
-                .isEqualTo("1.2.840.113549.1.12.1.3");
+        assertThat(enriched.hasChildOfType(Oid.class).get().asString()).isEqualTo(expectedOid);
+    }
+
+    @ParameterizedTest
+    @MethodSource("noOidTable")
+    void noOidForUnknownKeyLength(PBES1 pbes1) {
+        final INode enriched = new PBES1Enricher().enrich(pbes1);
+
+        assertThat(enriched.hasChildOfType(Oid.class)).isEmpty();
+    }
+
+    static Stream<Arguments> noOidTable() {
+        return Stream.of(
+                // No PKCS#5 OID defined for SHA1+RC4 with key lengths other than 128 or 40
+                Arguments.of(Named.of("SHA+RC4-64", pbes1(new SHA(LOC), new RC4(64, LOC)))));
+    }
+
+    private static PBES1 pbes1(MessageDigest digest, Cipher cipher) {
+        return new PBES1(digest, cipher);
     }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/PBES1.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/PBES1.java
@@ -51,11 +51,6 @@ public class PBES1 extends Algorithm implements PasswordBasedEncryption {
 
     public PBES1(@Nonnull DetectionLocation detectionLocation) {
         super(NAME, PasswordBasedEncryption.class, detectionLocation);
-        /*
-         * TODO: add OIDs from the RFC. See also:
-         * https://www.alvestrand.no/objectid/1.2.840.113549.1.5.html
-         * https://www.alvestrand.no/objectid/1.2.840.113549.1.12.1.html
-         */
     }
 
     // example: PBEWithHmacSHA1AndAES_128

--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,12 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
-        </dependency> 
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-launcher</artifactId>


### PR DESCRIPTION
### Description
Added OID resolution for PBES1 algorithm combinations during the enrichment phase. This ensures CBOM output includes correct OIDs for both PKCS#5 and PKCS#12 variants, which were previously missing.

### Changes
- Created `PBES1Enricher` to map digest/cipher combinations to their respective OIDs (RFC 2898 and PKCS#12).
- Registered the new enricher in the `Enricher` pipeline.
- Removed legacy TODO from `PBES1.java`.
- Added `PBES1EnricherTest` with coverage for PKCS#5 and PKCS#12 scenarios.

### Related Issues
Fixes #384

### Verification
- Ran `mvn test -pl enricher -Dtest=PBES1EnricherTest`.
- Confirmed correct OID resolution for:
    - MD5 + DES (1.2.840.113549.1.5.3)
    - SHA1 + 3-Key TripleDES (1.2.840.113549.1.12.1.3)

### Screenshots
Attached is a screenshot showing the node tree before and after enrichment, confirming the OID is correctly resolved:
<img width="1236" height="833" alt="Screenshot 2026-05-03 204349" src="https://github.com/user-attachments/assets/49e9da1a-c1e6-4641-a5af-5f442f5ed21b" />

