### PR TITLE
test(python): verify detection inside custom functions (part of #9)

### DIFF
--- a/python/src/test/files/rules/detection/mac/PycaMacDetectionInCustomFunctionTestFile.py
+++ b/python/src/test/files/rules/detection/mac/PycaMacDetectionInCustomFunctionTestFile.py
@@ -1,0 +1,27 @@
+from cryptography.hazmat.primitives import hmac
+from cryptography.hazmat.primitives import hashes
+
+def custom_sign(key, data):
+    # Custom function with cryptographic operation
+    algorithm = hashes.SHA256()
+    hmac_obj = hmac.HMAC(key, algorithm)  # Noncompliant {{(Mac) HMAC-SHA256}}
+    hmac_obj.update(data)
+    return hmac_obj.finalize()
+
+def non_crypto_function(text):
+    # Non-cryptographic function - should not trigger detection
+    result = "not crypto: " + text
+    return result.upper()
+
+# Example usage
+if __name__ == "__main__":
+    key = b'SecretKey123'
+    data = b'This is some data'
+    
+    # Cryptographic operation in custom function is detected
+    result = custom_sign(key, data)
+    print("HMAC Result:", result.hex())
+    
+    # Non-cryptographic function call does not trigger detection
+    text_result = non_crypto_function("hello")
+    print("Text Result:", text_result)

--- a/python/src/test/java/com/ibm/plugin/rules/detection/mac/PycaMacDetectionInCustomFunctionTest.java
+++ b/python/src/test/java/com/ibm/plugin/rules/detection/mac/PycaMacDetectionInCustomFunctionTest.java
@@ -1,0 +1,131 @@
+/*
+ * Sonar Cryptography Plugin
+ * Copyright (C) 2024 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.plugin.rules.detection.mac;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ibm.engine.detection.DetectionStore;
+import com.ibm.engine.model.Algorithm;
+import com.ibm.engine.model.IValue;
+import com.ibm.engine.model.context.MacContext;
+import com.ibm.mapper.model.BlockSize;
+import com.ibm.mapper.model.DigestSize;
+import com.ibm.mapper.model.INode;
+import com.ibm.mapper.model.Mac;
+import com.ibm.mapper.model.MessageDigest;
+import com.ibm.mapper.model.Oid;
+import com.ibm.mapper.model.functionality.Digest;
+import com.ibm.mapper.model.functionality.Tag;
+import com.ibm.plugin.TestBase;
+import java.util.List;
+import javax.annotation.Nonnull;
+import org.junit.jupiter.api.Test;
+import org.sonar.plugins.python.api.PythonCheck;
+import org.sonar.plugins.python.api.PythonVisitorContext;
+import org.sonar.plugins.python.api.symbols.Symbol;
+import org.sonar.plugins.python.api.tree.Tree;
+import org.sonar.python.checks.utils.PythonCheckVerifier;
+
+/**
+ * Verifies that cryptographic operations inside user-defined functions are detected during
+ * standard AST traversal. This test covers both positive cases (cryptographic operations) and
+ * negative cases (non-cryptographic functions).
+ */
+class PycaMacDetectionInCustomFunctionTest extends TestBase {
+
+    @Test
+    void testCryptographicOperationInCustomFunction() {
+        PythonCheckVerifier.verify(
+                "src/test/files/rules/detection/mac/PycaMacDetectionInCustomFunctionTestFile.py",
+                this);
+    }
+
+    @Override
+    public void asserts(
+            int findingId,
+            @Nonnull DetectionStore<PythonCheck, Tree, Symbol, PythonVisitorContext> detectionStore,
+            @Nonnull List<INode> nodes) {
+
+        // Verifies that cryptographic operations inside user-defined functions are detected
+        // during standard AST traversal.
+
+        /*
+         * Detection Store
+         */
+        assertThat(detectionStore.getDetectionValues()).hasSize(1);
+        assertThat(detectionStore.getDetectionValueContext()).isInstanceOf(MacContext.class);
+        IValue<Tree> value0 = detectionStore.getDetectionValues().get(0);
+        assertThat(value0).isInstanceOf(Algorithm.class);
+        assertThat(value0.asString()).isEqualTo("SHA256");
+
+        /*
+         * Translation
+         */
+        assertThat(nodes).hasSize(1);
+
+        // Mac
+        INode macNode = nodes.get(0);
+        assertThat(macNode.getKind()).isEqualTo(Mac.class);
+        assertThat(macNode.getChildren()).hasSize(3);
+        assertThat(macNode.asString()).isEqualTo("HMAC-SHA256");
+
+        // MessageDigest under Mac
+        INode messageDigestNode = macNode.getChildren().get(MessageDigest.class);
+        assertThat(messageDigestNode).isNotNull();
+        assertThat(messageDigestNode.getChildren()).hasSize(4);
+        assertThat(messageDigestNode.asString()).isEqualTo("SHA256");
+
+        // Digest under MessageDigest under Mac
+        INode digestNode = messageDigestNode.getChildren().get(Digest.class);
+        assertThat(digestNode).isNotNull();
+        assertThat(digestNode.getChildren()).isEmpty();
+        assertThat(digestNode.asString()).isEqualTo("DIGEST");
+
+        // BlockSize under MessageDigest under Mac
+        INode blockSizeNode = messageDigestNode.getChildren().get(BlockSize.class);
+        assertThat(blockSizeNode).isNotNull();
+        assertThat(blockSizeNode.getChildren()).isEmpty();
+        assertThat(blockSizeNode.asString()).isEqualTo("512");
+
+        // Oid under MessageDigest under Mac
+        INode oidNode = messageDigestNode.getChildren().get(Oid.class);
+        assertThat(oidNode).isNotNull();
+        assertThat(oidNode.getChildren()).isEmpty();
+        assertThat(oidNode.asString()).isEqualTo("2.16.840.1.101.3.4.2.1");
+
+        // DigestSize under MessageDigest under Mac
+        INode digestSizeNode = messageDigestNode.getChildren().get(DigestSize.class);
+        assertThat(digestSizeNode).isNotNull();
+        assertThat(digestSizeNode.getChildren()).isEmpty();
+        assertThat(digestSizeNode.asString()).isEqualTo("256");
+
+        // Tag under Mac
+        INode tagNode = macNode.getChildren().get(Tag.class);
+        assertThat(tagNode).isNotNull();
+        assertThat(tagNode.getChildren()).isEmpty();
+        assertThat(tagNode.asString()).isEqualTo("TAG");
+
+        // Oid under Mac
+        INode oidNode1 = macNode.getChildren().get(Oid.class);
+        assertThat(oidNode1).isNotNull();
+        assertThat(oidNode1.getChildren()).isEmpty();
+        assertThat(oidNode1.asString()).isEqualTo("1.2.840.113549.2.9");
+    }
+}


### PR DESCRIPTION
Adds a regression test to verify that cryptographic operations inside user-defined
functions are correctly detected during standard AST traversal.

### Motivation
While investigating issue #9, this PR validates that detection inside same-file
wrapper functions is already supported by the current visitor-based analysis.

This helps clarify that the remaining gaps in #9 are primarily related to
cross-file resolution and linking, rather than intra-file traversal.

### Changes
- Rename test to `PycaMacDetectionInCustomFunctionTest` for clarity
- Add negative test case to ensure non-cryptographic functions do not trigger findings
- Improve assertions and documentation for better readability and maintainability

### Scope
- No changes to detection logic
- Improves test coverage and documents existing behavior

### Example Covered

```python
def custom_sign(key, data):
    algorithm = hashes.SHA256()
    hmac_obj = hmac.HMAC(key, algorithm)  # detected
    hmac_obj.update(data)
    return hmac_obj.finalize()