### PR TITLE
feat(cpp): add base CppTree interface

### DIFF
--- a/cpp/pom.xml
+++ b/cpp/pom.xml
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ CBOMkit sonar-cryptography plugin
+  ~ Copyright (C) 2024 PQCA
+  ~
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                             http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.ibm</groupId>
+        <artifactId>sonar-cryptography</artifactId>
+        <version>1.5.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>sonar-cryptography-cpp</artifactId>
+    <name>Sonar Cryptography Plugin :: C/C++</name>
+    <description>
+        C and C++ language support for the Sonar Cryptography Plugin,
+        with detection rules for OpenSSL and other cryptographic libraries.
+    </description>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+
+        <!-- ── Internal modules ─────────────────────────────────────────── -->
+        <dependency>
+            <groupId>com.ibm</groupId>
+            <artifactId>sonar-cryptography-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.ibm</groupId>
+            <artifactId>sonar-cryptography-engine</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.ibm</groupId>
+            <artifactId>sonar-cryptography-mapper</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.ibm</groupId>
+            <artifactId>sonar-cryptography-enricher</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.ibm</groupId>
+            <artifactId>sonar-cryptography-output</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- ── SonarQube API ────────────────────────────────────────────── -->
+        <dependency>
+            <groupId>org.sonarsource.api.plugin</groupId>
+            <artifactId>sonar-plugin-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- ── ANTLR4 runtime (grammar lives in engine module) ──────────── -->
+        <dependency>
+            <groupId>org.antlr</groupId>
+            <artifactId>antlr4-runtime</artifactId>
+        </dependency>
+
+        <!-- ── Annotations ──────────────────────────────────────────────── -->
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+        </dependency>
+
+        <!-- ── Logging ──────────────────────────────────────────────────── -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <!-- ── Test dependencies ────────────────────────────────────────── -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.sonarsource.api.plugin</groupId>
+            <artifactId>sonar-plugin-api-test-fixtures</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+
+            <!-- ── Google Java Format (AOSP style, matches rest of project) -->
+            <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+            </plugin>
+
+            <!-- ── Surefire for JUnit 5 ──────────────────────────────────── -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+
+        </plugins>
+    </build>
+
+</project>

--- a/engine/src/main/antlr4/com/ibm/engine/language/csharp/antlr/CLexer.g4
+++ b/engine/src/main/antlr4/com/ibm/engine/language/csharp/antlr/CLexer.g4
@@ -1,0 +1,359 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * C Lexer Grammar for CBOMkit sonar-cryptography plugin.
+ * Adapted from the ANTLR4 grammars-v4 C grammar:
+ * https://github.com/antlr/grammars-v4/tree/master/c
+ *
+ * Supports C89, C99, C11 constructs sufficient for detecting
+ * OpenSSL and other cryptographic library API calls.
+ */
+lexer grammar CLexer;
+
+// ---------------------------------------------------------------------------
+// Keywords
+// ---------------------------------------------------------------------------
+
+Auto        : 'auto';
+Break       : 'break';
+Case        : 'case';
+Char        : 'char';
+Const       : 'const';
+Continue    : 'continue';
+Default     : 'default';
+Do          : 'do';
+Double      : 'double';
+Else        : 'else';
+Enum        : 'enum';
+Extern      : 'extern';
+Float       : 'float';
+For         : 'for';
+Goto        : 'goto';
+If          : 'if';
+Inline      : 'inline';
+Int         : 'int';
+Long        : 'long';
+Register    : 'register';
+Restrict    : 'restrict';
+Return      : 'return';
+Short       : 'short';
+Signed      : 'signed';
+Sizeof      : 'sizeof';
+Static      : 'static';
+Struct      : 'struct';
+Switch      : 'switch';
+Typedef     : 'typedef';
+Union       : 'union';
+Unsigned    : 'unsigned';
+Void        : 'void';
+Volatile    : 'volatile';
+While       : 'while';
+
+// C11 keywords
+Alignas         : '_Alignas';
+Alignof         : '_Alignof';
+Atomic          : '_Atomic';
+Bool            : '_Bool';
+Complex         : '_Complex';
+Generic         : '_Generic';
+Imaginary       : '_Imaginary';
+Noreturn        : '_Noreturn';
+StaticAssert    : '_Static_assert';
+ThreadLocal     : '_Thread_local';
+
+// GCC extensions (common in OpenSSL code)
+BuiltinVaArg    : '__builtin_va_arg';
+BuiltinOffsetof : '__builtin_offsetof';
+
+// ---------------------------------------------------------------------------
+// Punctuators and operators
+// ---------------------------------------------------------------------------
+
+LeftParen       : '(';
+RightParen      : ')';
+LeftBracket     : '[';
+RightBracket    : ']';
+LeftBrace       : '{';
+RightBrace      : '}';
+
+Less            : '<';
+LessEqual       : '<=';
+Greater         : '>';
+GreaterEqual    : '>=';
+LeftShift       : '<<';
+RightShift      : '>>';
+
+Plus            : '+';
+PlusPlus        : '++';
+Minus           : '-';
+MinusMinus      : '--';
+Star            : '*';
+Div             : '/';
+Mod             : '%';
+
+And             : '&';
+Or              : '|';
+AndAnd          : '&&';
+OrOr            : '||';
+Caret           : '^';
+Not             : '!';
+Tilde           : '~';
+
+Question        : '?';
+Colon           : ':';
+Semi            : ';';
+Comma           : ',';
+Assign          : '=';
+
+// Compound assignment operators
+StarAssign      : '*=';
+DivAssign       : '/=';
+ModAssign       : '%=';
+PlusAssign      : '+=';
+MinusAssign     : '-=';
+LeftShiftAssign : '<<=';
+RightShiftAssign: '>>=';
+AndAssign       : '&=';
+XorAssign       : '^=';
+OrAssign        : '|=';
+
+Equal           : '==';
+NotEqual        : '!=';
+
+Arrow           : '->';
+Dot             : '.';
+Ellipsis        : '...';
+
+// ---------------------------------------------------------------------------
+// Literals
+// ---------------------------------------------------------------------------
+
+IntegerConstant
+    : DecimalConstant IntegerSuffix?
+    | OctalConstant IntegerSuffix?
+    | HexadecimalConstant IntegerSuffix?
+    | BinaryConstant
+    ;
+
+fragment BinaryConstant
+    : '0' [bB] [0-1]+
+    ;
+
+fragment DecimalConstant
+    : NonzeroDigit Digit*
+    ;
+
+fragment OctalConstant
+    : '0' OctalDigit*
+    ;
+
+fragment HexadecimalConstant
+    : HexadecimalPrefix HexadecimalDigit+
+    ;
+
+fragment HexadecimalPrefix
+    : '0' [xX]
+    ;
+
+fragment IntegerSuffix
+    : UnsignedSuffix LongSuffix?
+    | UnsignedSuffix LongLongSuffix
+    | LongSuffix UnsignedSuffix?
+    | LongLongSuffix UnsignedSuffix?
+    ;
+
+fragment UnsignedSuffix
+    : [uU]
+    ;
+
+fragment LongSuffix
+    : [lL]
+    ;
+
+fragment LongLongSuffix
+    : 'll' | 'LL'
+    ;
+
+FloatingConstant
+    : DecimalFloatingConstant
+    | HexadecimalFloatingConstant
+    ;
+
+fragment DecimalFloatingConstant
+    : FractionalConstant ExponentPart? FloatingSuffix?
+    | DigitSequence ExponentPart FloatingSuffix?
+    ;
+
+fragment HexadecimalFloatingConstant
+    : HexadecimalPrefix (HexadecimalFractionalConstant | HexadecimalDigitSequence) BinaryExponentPart FloatingSuffix?
+    ;
+
+fragment FractionalConstant
+    : DigitSequence? '.' DigitSequence
+    | DigitSequence '.'
+    ;
+
+fragment ExponentPart
+    : [eE] Sign? DigitSequence
+    ;
+
+fragment Sign
+    : [+-]
+    ;
+
+fragment DigitSequence
+    : Digit+
+    ;
+
+fragment HexadecimalFractionalConstant
+    : HexadecimalDigitSequence? '.' HexadecimalDigitSequence
+    | HexadecimalDigitSequence '.'
+    ;
+
+fragment BinaryExponentPart
+    : [pP] Sign? DigitSequence
+    ;
+
+fragment HexadecimalDigitSequence
+    : HexadecimalDigit+
+    ;
+
+fragment FloatingSuffix
+    : [flFL]
+    ;
+
+CharacterConstant
+    : '\'' CCharSequence '\''
+    | 'L\'' CCharSequence '\''
+    | 'u\'' CCharSequence '\''
+    | 'U\'' CCharSequence '\''
+    ;
+
+fragment CCharSequence
+    : CChar+
+    ;
+
+fragment CChar
+    : ~['\\\r\n]
+    | EscapeSequence
+    ;
+
+StringLiteral
+    : EncodingPrefix? '"' SCharSequence? '"'
+    ;
+
+fragment EncodingPrefix
+    : 'u8' | 'u' | 'U' | 'L'
+    ;
+
+fragment SCharSequence
+    : SChar+
+    ;
+
+fragment SChar
+    : ~["\\\r\n]
+    | EscapeSequence
+    | '\\\n'    // Added line
+    | '\\\r\n'  // Added line
+    ;
+
+fragment EscapeSequence
+    : SimpleEscapeSequence
+    | OctalEscapeSequence
+    | HexadecimalEscapeSequence
+    | UniversalCharacterName
+    ;
+
+fragment SimpleEscapeSequence
+    : '\\' ['"?abfnrtvv\\]
+    ;
+
+fragment OctalEscapeSequence
+    : '\\' OctalDigit OctalDigit? OctalDigit?
+    ;
+
+fragment HexadecimalEscapeSequence
+    : '\\x' HexadecimalDigit+
+    ;
+
+// ---------------------------------------------------------------------------
+// Identifiers
+// ---------------------------------------------------------------------------
+
+Identifier
+    : IdentifierNondigit (IdentifierNondigit | Digit)*
+    ;
+
+fragment IdentifierNondigit
+    : Nondigit
+    | UniversalCharacterName
+    ;
+
+fragment Nondigit
+    : [a-zA-Z_]
+    ;
+
+fragment Digit
+    : [0-9]
+    ;
+
+fragment NonzeroDigit
+    : [1-9]
+    ;
+
+fragment OctalDigit
+    : [0-7]
+    ;
+
+fragment HexadecimalDigit
+    : [0-9a-fA-F]
+    ;
+
+fragment UniversalCharacterName
+    : '\\u' HexadecimalDigit HexadecimalDigit HexadecimalDigit HexadecimalDigit
+    | '\\U' HexadecimalDigit HexadecimalDigit HexadecimalDigit HexadecimalDigit
+              HexadecimalDigit HexadecimalDigit HexadecimalDigit HexadecimalDigit
+    ;
+
+// ---------------------------------------------------------------------------
+// Preprocessor directives (skip — we do not expand macros)
+// ---------------------------------------------------------------------------
+
+Directive
+    : '#' ~[\r\n]* -> skip
+    ;
+
+// ---------------------------------------------------------------------------
+// Whitespace and comments
+// ---------------------------------------------------------------------------
+
+Whitespace
+    : [ \t]+ -> skip
+    ;
+
+Newline
+    : ( '\r' '\n'? | '\n' ) -> skip
+    ;
+
+BlockComment
+    : '/*' .*? '*/' -> skip
+    ;
+
+LineComment
+    : '//' ~[\r\n]* -> skip
+    ;

--- a/engine/src/main/antlr4/com/ibm/engine/language/csharp/antlr/CParser.g4
+++ b/engine/src/main/antlr4/com/ibm/engine/language/csharp/antlr/CParser.g4
@@ -1,0 +1,494 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * C Parser Grammar for CBOMkit sonar-cryptography plugin.
+ * Adapted from the ANTLR4 grammars-v4 C grammar:
+ * https://github.com/antlr/grammars-v4/tree/master/c
+ *
+ * Supports C89, C99, C11 constructs sufficient for detecting
+ * OpenSSL and other cryptographic library API calls.
+ *
+ * Key design goals:
+ * - Detect function calls: EVP_EncryptInit_ex(ctx, EVP_aes_256_cbc(), ...)
+ * - Detect string literals used as algorithm identifiers
+ * - Detect integer constants used as key sizes
+ * - Handle pointer dereferences and struct member access
+ */
+parser grammar CParser;
+
+options {
+    tokenVocab = CLexer;
+}
+
+// ---------------------------------------------------------------------------
+// Top-level rule
+// ---------------------------------------------------------------------------
+
+compilationUnit
+    : translationUnit? EOF
+    ;
+
+translationUnit
+    : externalDeclaration+
+    ;
+
+externalDeclaration
+    : functionDefinition
+    | declaration
+    | Semi  // stray semicolons
+    ;
+
+// ---------------------------------------------------------------------------
+// Function definitions
+// ---------------------------------------------------------------------------
+
+functionDefinition
+    : declarationSpecifiers declarator declarationList? compoundStatement
+    ;
+
+declarationList
+    : declaration+
+    ;
+
+// ---------------------------------------------------------------------------
+// Declarations
+// ---------------------------------------------------------------------------
+
+declaration
+    : declarationSpecifiers initDeclaratorList? Semi
+    | staticAssertDeclaration
+    ;
+
+declarationSpecifiers
+    : declarationSpecifier+
+    ;
+
+declarationSpecifiers2
+    : declarationSpecifier+
+    ;
+
+declarationSpecifier
+    : storageClassSpecifier
+    | typeSpecifier
+    | typeQualifier
+    | functionSpecifier
+    | alignmentSpecifier
+    ;
+
+initDeclaratorList
+    : initDeclarator ( Comma initDeclarator )*
+    ;
+
+initDeclarator
+    : declarator ( Assign initializer )?
+    ;
+
+storageClassSpecifier
+    : Typedef
+    | Extern
+    | Static
+    | ThreadLocal
+    | Auto
+    | Register
+    ;
+
+typeSpecifier
+    : Void
+    | Char
+    | Short
+    | Int
+    | Long
+    | Float
+    | Double
+    | Signed
+    | Unsigned
+    | Bool
+    | Complex
+    | atomicTypeSpecifier
+    | structOrUnionSpecifier
+    | enumSpecifier
+    | typedefName
+    | typeofSpecifier
+    ;
+
+// typeof() — GCC extension common in OpenSSL
+typeofSpecifier
+    : '__typeof__' LeftParen (expression | typeName) RightParen
+    | '__typeof' LeftParen (expression | typeName) RightParen
+    ;
+
+structOrUnionSpecifier
+    : structOrUnion Identifier? LeftBrace structDeclarationList RightBrace
+    | structOrUnion Identifier
+    ;
+
+structOrUnion
+    : 'struct'
+    | 'union'
+    ;
+
+structDeclarationList
+    : structDeclaration+
+    ;
+
+structDeclaration
+    : specifierQualifierList structDeclaratorList? Semi
+    | staticAssertDeclaration
+    ;
+
+specifierQualifierList
+    : (typeSpecifier | typeQualifier | alignmentSpecifier)+
+    ;
+
+structDeclaratorList
+    : structDeclarator (Comma structDeclarator)*
+    ;
+
+structDeclarator
+    : declarator
+    | declarator? Colon constantExpression
+    ;
+
+enumSpecifier
+    : 'enum' Identifier? LeftBrace enumeratorList Comma? RightBrace
+    | 'enum' Identifier
+    ;
+
+enumeratorList
+    : enumerator (Comma enumerator)*
+    ;
+
+enumerator
+    : enumerationConstant (Assign constantExpression)?
+    ;
+
+enumerationConstant
+    : Identifier
+    ;
+
+atomicTypeSpecifier
+    : Atomic LeftParen typeName RightParen
+    ;
+
+typeQualifier
+    : Const
+    | Restrict
+    | Volatile
+    | Atomic
+    ;
+
+functionSpecifier
+    : Inline
+    | Noreturn
+    ;
+
+alignmentSpecifier
+    : Alignas LeftParen (typeName | constantExpression) RightParen
+    ;
+
+declarator
+    : pointer? directDeclarator
+    ;
+
+directDeclarator
+    : Identifier
+    | LeftParen declarator RightParen
+    | directDeclarator LeftBracket typeQualifierList? assignmentExpression? RightBracket
+    | directDeclarator LeftBracket Static typeQualifierList? assignmentExpression RightBracket
+    | directDeclarator LeftBracket typeQualifierList Static assignmentExpression RightBracket
+    | directDeclarator LeftBracket typeQualifierList? Star RightBracket
+    | directDeclarator LeftParen parameterTypeList RightParen
+    | directDeclarator LeftParen identifierList? RightParen
+    ;
+
+pointer
+    : ( Star typeQualifierList? )+
+    ;
+
+typeQualifierList
+    : typeQualifier+
+    ;
+
+parameterTypeList
+    : parameterList ( Comma Ellipsis )?
+    ;
+
+parameterList
+    : parameterDeclaration ( Comma parameterDeclaration )*
+    ;
+
+parameterDeclaration
+    : declarationSpecifiers declarator
+    | declarationSpecifiers2 abstractDeclarator?
+    ;
+
+identifierList
+    : Identifier ( Comma Identifier )*
+    ;
+
+typeName
+    : specifierQualifierList abstractDeclarator?
+    ;
+
+abstractDeclarator
+    : pointer
+    | pointer? directAbstractDeclarator
+    ;
+
+directAbstractDeclarator
+    : LeftParen abstractDeclarator RightParen
+    | LeftBracket typeQualifierList? assignmentExpression? RightBracket
+    | LeftBracket Static typeQualifierList? assignmentExpression RightBracket
+    | LeftBracket typeQualifierList Static assignmentExpression RightBracket
+    | LeftBracket Star RightBracket
+    | LeftParen parameterTypeList? RightParen
+    | directAbstractDeclarator LeftBracket typeQualifierList? assignmentExpression? RightBracket
+    | directAbstractDeclarator LeftBracket Static typeQualifierList? assignmentExpression RightBracket
+    | directAbstractDeclarator LeftBracket typeQualifierList Static assignmentExpression RightBracket
+    | directAbstractDeclarator LeftBracket Star RightBracket
+    | directAbstractDeclarator LeftParen parameterTypeList? RightParen
+    ;
+
+typedefName
+    : Identifier
+    ;
+
+initializer
+    : assignmentExpression
+    | LeftBrace initializerList Comma? RightBrace
+    ;
+
+initializerList
+    : designation? initializer ( Comma designation? initializer )*
+    ;
+
+designation
+    : designatorList Assign
+    ;
+
+designatorList
+    : designator+
+    ;
+
+designator
+    : LeftBracket constantExpression RightBracket
+    | Dot Identifier
+    ;
+
+staticAssertDeclaration
+    : StaticAssert LeftParen constantExpression Comma StringLiteral+ RightParen Semi
+    ;
+
+// ---------------------------------------------------------------------------
+// Statements
+// ---------------------------------------------------------------------------
+
+statement
+    : labeledStatement
+    | compoundStatement
+    | expressionStatement
+    | selectionStatement
+    | iterationStatement
+    | jumpStatement
+    ;
+
+labeledStatement
+    : Identifier Colon statement
+    | Case constantExpression Colon statement
+    | Default Colon statement
+    ;
+
+compoundStatement
+    : LeftBrace blockItemList? RightBrace
+    ;
+
+blockItemList
+    : blockItem+
+    ;
+
+blockItem
+    : statement
+    | declaration
+    ;
+
+expressionStatement
+    : expression? Semi
+    ;
+
+selectionStatement
+    : If LeftParen expression RightParen statement ( Else statement )?
+    | Switch LeftParen expression RightParen statement
+    ;
+
+iterationStatement
+    : While LeftParen expression RightParen statement
+    | Do statement While LeftParen expression RightParen Semi
+    | For LeftParen forCondition RightParen statement
+    ;
+
+forCondition
+    : ( forDeclaration | expression? ) Semi forExpression? Semi forExpression?
+    ;
+
+forDeclaration
+    : declarationSpecifiers initDeclaratorList?
+    ;
+
+forExpression
+    : assignmentExpression ( Comma assignmentExpression )*
+    ;
+
+jumpStatement
+    : Goto Identifier Semi
+    | Continue Semi
+    | Break Semi
+    | Return expression? Semi
+    ;
+
+// ---------------------------------------------------------------------------
+// Expressions
+// ---------------------------------------------------------------------------
+
+compilationUnit2
+    : expression EOF
+    ;
+
+expression
+    : assignmentExpression ( Comma assignmentExpression )*
+    ;
+
+assignmentExpression
+    : conditionalExpression
+    | unaryExpression assignmentOperator assignmentExpression
+    ;
+
+assignmentOperator
+    : Assign | StarAssign | DivAssign | ModAssign | PlusAssign | MinusAssign
+    | LeftShiftAssign | RightShiftAssign | AndAssign | XorAssign | OrAssign
+    ;
+
+conditionalExpression
+    : logicalOrExpression ( Question expression Colon conditionalExpression )?
+    ;
+
+logicalOrExpression
+    : logicalAndExpression ( OrOr logicalAndExpression )*
+    ;
+
+logicalAndExpression
+    : inclusiveOrExpression ( AndAnd inclusiveOrExpression )*
+    ;
+
+inclusiveOrExpression
+    : exclusiveOrExpression ( Or exclusiveOrExpression )*
+    ;
+
+exclusiveOrExpression
+    : andExpression ( Caret andExpression )*
+    ;
+
+andExpression
+    : equalityExpression ( And equalityExpression )*
+    ;
+
+equalityExpression
+    : relationalExpression ( ( Equal | NotEqual ) relationalExpression )*
+    ;
+
+relationalExpression
+    : shiftExpression ( ( Less | Greater | LessEqual | GreaterEqual ) shiftExpression )*
+    ;
+
+shiftExpression
+    : additiveExpression ( ( LeftShift | RightShift ) additiveExpression )*
+    ;
+
+additiveExpression
+    : multiplicativeExpression ( ( Plus | Minus ) multiplicativeExpression )*
+    ;
+
+multiplicativeExpression
+    : castExpression ( ( Star | Div | Mod ) castExpression )*
+    ;
+
+castExpression
+    : LeftParen typeName RightParen castExpression
+    | unaryExpression
+    ;
+
+unaryExpression
+    : postfixExpression
+    | PlusPlus unaryExpression
+    | MinusMinus unaryExpression
+    | unaryOperator castExpression
+    | Sizeof ( unaryExpression | LeftParen typeName RightParen )
+    | Alignof LeftParen typeName RightParen
+    | BuiltinVaArg LeftParen unaryExpression Comma typeName RightParen
+    | BuiltinOffsetof LeftParen typeName Comma unaryExpression RightParen
+    ;
+
+unaryOperator
+    : And | Star | Plus | Minus | Tilde | Not
+    ;
+
+// ---------------------------------------------------------------------------
+// Postfix expressions — KEY RULE for detecting function calls
+// ---------------------------------------------------------------------------
+
+postfixExpression
+    : primaryExpression
+    | postfixExpression LeftBracket expression RightBracket          // array index
+    | postfixExpression LeftParen argumentExpressionList? RightParen // FUNCTION CALL ← detect this
+    | postfixExpression ( Dot | Arrow ) Identifier                   // member access
+    | postfixExpression ( PlusPlus | MinusMinus )
+    | LeftParen typeName RightParen LeftBrace initializerList Comma? RightBrace
+    ;
+
+argumentExpressionList
+    : assignmentExpression ( Comma assignmentExpression )*
+    ;
+
+primaryExpression
+    : Identifier
+    | Constant
+    | StringLiteral+
+    | LeftParen expression RightParen
+    | genericSelection
+    ;
+
+Constant
+    : IntegerConstant
+    | FloatingConstant
+    | CharacterConstant
+    ;
+
+genericSelection
+    : Generic LeftParen assignmentExpression Comma genericAssocList RightParen
+    ;
+
+genericAssocList
+    : genericAssociation ( Comma genericAssociation )*
+    ;
+
+genericAssociation
+    : ( typeName | Default ) Colon assignmentExpression
+    ;
+
+constantExpression
+    : conditionalExpression
+    ;

--- a/engine/src/main/java/com/ibm/engine/language/cpp/CppCheck.java
+++ b/engine/src/main/java/com/ibm/engine/language/cpp/CppCheck.java
@@ -1,0 +1,36 @@
+/*
+ * Sonar Cryptography Plugin
+ * Copyright (C) 2025 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.engine.language.cpp;
+
+/**
+ * Marker interface for C/C++ detection rules.
+ *
+ * <p>This interface fills the {@code R} (Rule) generic type parameter used throughout the engine.
+ * It is the C/C++ equivalent of {@code JavaCheck} in the Java language support and {@code
+ * CSharpCheck} in the C# language support.
+ *
+ * <p>All C/C++ detection rule classes should implement this interface so that the engine's generic
+ * machinery can operate in a type-safe way across language modules.
+ */
+public interface CppCheck {
+    // Marker interface — no methods required.
+    // The engine uses this as a type bound: IDetectionRule<CppTree>,
+    // ILanguageSupport<CppCheck, CppTree, CppSymbol, CppScanContext>, etc.
+}

--- a/engine/src/main/java/com/ibm/engine/language/cpp/CppSymbol.java
+++ b/engine/src/main/java/com/ibm/engine/language/cpp/CppSymbol.java
@@ -1,0 +1,109 @@
+/*
+ * Sonar Cryptography Plugin
+ * Copyright (C) 2025 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.engine.language.cpp;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Represents a symbol (variable, function, or type name) in C/C++ source code.
+ *
+ * <p>This class fills the {@code S} (Symbol) generic type parameter used throughout the engine. It
+ * is the C/C++ equivalent of {@code Symbol} in the Java language support and {@code CSharpSymbol}
+ * in the C# language support.
+ *
+ * <p>In C/C++, because we use ANTLR for parsing (not a full Sonar language analyzer), we do not
+ * have a rich semantic model with full type resolution. This class therefore provides a lightweight
+ * symbol representation based on the identifier name and its resolved string value (if any).
+ *
+ * <p>Known limitation: unlike Java's {@code Symbol}, this class does not support cross-method
+ * variable tracking. Symbol resolution is limited to single-function scope, consistent with the
+ * current C# implementation approach.
+ */
+public final class CppSymbol {
+
+    /** The name of the identifier as it appears in source code (e.g., {@code "ctx"}, {@code "key"}). */
+    @Nonnull private final String name;
+
+    /**
+     * The resolved string value of this symbol, if it can be statically determined. For example,
+     * if the code contains {@code const char *algo = "AES-256-CBC"}, then {@code resolvedValue}
+     * would be {@code "AES-256-CBC"}. {@code null} if the value cannot be statically resolved.
+     */
+    @Nullable private final String resolvedValue;
+
+    /**
+     * Creates a new {@code CppSymbol} with a name and no resolved value.
+     *
+     * @param name the identifier name as it appears in source code
+     */
+    public CppSymbol(@Nonnull String name) {
+        this.name = name;
+        this.resolvedValue = null;
+    }
+
+    /**
+     * Creates a new {@code CppSymbol} with both a name and a statically resolved value.
+     *
+     * @param name the identifier name as it appears in source code
+     * @param resolvedValue the statically resolved string value, or {@code null} if not resolvable
+     */
+    public CppSymbol(@Nonnull String name, @Nullable String resolvedValue) {
+        this.name = name;
+        this.resolvedValue = resolvedValue;
+    }
+
+    /**
+     * Returns the identifier name as it appears in source code.
+     *
+     * @return the symbol name, never {@code null}
+     */
+    @Nonnull
+    public String name() {
+        return name;
+    }
+
+    /**
+     * Returns the statically resolved string value of this symbol, if available.
+     *
+     * @return the resolved value, or {@code null} if it cannot be statically determined
+     */
+    @Nullable
+    public String resolvedValue() {
+        return resolvedValue;
+    }
+
+    /**
+     * Returns {@code true} if this symbol has a statically resolved value.
+     *
+     * @return {@code true} if {@link #resolvedValue()} is non-null
+     */
+    public boolean isResolved() {
+        return resolvedValue != null;
+    }
+
+    @Override
+    public String toString() {
+        if (resolvedValue != null) {
+            return "CppSymbol{name='" + name + "', resolvedValue='" + resolvedValue + "'}";
+        }
+        return "CppSymbol{name='" + name + "'}";
+    }
+}

--- a/engine/src/main/java/com/ibm/engine/language/cpp/tree/CppTree.java
+++ b/engine/src/main/java/com/ibm/engine/language/cpp/tree/CppTree.java
@@ -1,0 +1,99 @@
+/*
+ * Sonar Cryptography Plugin
+ * Copyright (C) 2025 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.engine.language.cpp.tree;
+
+/**
+ * Base interface for all C/C++ abstract syntax tree (AST) nodes used by the engine.
+ *
+ * <p>This interface fills the {@code T} (Tree) generic type parameter used throughout the engine.
+ * It is the C/C++ equivalent of {@code Tree} in the Java language support (from the Sonar Java
+ * plugin API) and {@code CSharpTree} in the C# language support.
+ *
+ * <p>Because we use ANTLR to parse C/C++ source files directly (rather than a Sonar language
+ * plugin), we build our own lightweight tree node hierarchy rather than relying on a pre-existing
+ * AST API. Each concrete implementation of this interface represents a specific syntactic construct
+ * in C/C++ source code.
+ *
+ * <p>The concrete tree node types are:
+ *
+ * <ul>
+ *   <li>{@link CppLiteralTree} — string literals and numeric constants
+ *   <li>{@link CppIdentifierTree} — variable and function names
+ *   <li>{@link CppMethodInvocationTree} — function call expressions
+ *   <li>{@link CppMemberAccessTree} — {@code ->} and {@code .} member access
+ *   <li>{@link CppBlockTree} — compound statement / code block
+ * </ul>
+ *
+ * <p>The {@link Kind} enum allows the engine and detection rules to distinguish between node types
+ * without needing to use {@code instanceof} checks everywhere.
+ */
+public interface CppTree {
+
+    /**
+     * Enumerates the kinds of C/C++ tree nodes recognised by the engine.
+     *
+     * <p>This mirrors the role of the {@code Tree.Kind} enum in the Sonar Java plugin API.
+     */
+    enum Kind {
+        /** A string literal ({@code "AES-256-CBC"}) or numeric constant ({@code 256}). */
+        LITERAL,
+
+        /** A bare identifier — a variable name or function name used as an expression. */
+        IDENTIFIER,
+
+        /**
+         * A function call expression, e.g. {@code EVP_EncryptInit_ex(ctx, EVP_aes_256_cbc(),
+         * NULL, key, iv)}.
+         */
+        METHOD_INVOCATION,
+
+        /**
+         * A member access expression using {@code ->} or {@code .}, e.g. {@code ctx->cipher} or
+         * {@code params.key_len}.
+         */
+        MEMBER_ACCESS,
+
+        /** A compound statement enclosed in braces, i.e. a {@code { }} block. */
+        BLOCK,
+    }
+
+    /**
+     * Returns the kind of this tree node.
+     *
+     * @return the {@link Kind} of this node, never {@code null}
+     */
+    Kind kind();
+
+    /**
+     * Returns the 1-based line number in the source file where this node begins.
+     *
+     * <p>Used by the engine to record the detection location (file + line) in the CBOM output.
+     *
+     * @return line number ≥ 1
+     */
+    int line();
+
+    /**
+     * Returns the 0-based character offset within its line where this node begins.
+     *
+     * @return column offset ≥ 0
+     */
+    int column();
+}

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
         <module>python</module>
         <module>go</module>
         <module>csharp</module>
+        <module>cpp</module>
         <module>engine</module>
         <module>output</module>
         <module>common</module>

--- a/sonar-cryptography-plugin/pom.xml
+++ b/sonar-cryptography-plugin/pom.xml
@@ -47,6 +47,12 @@
             <version>2.0.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>com.ibm</groupId>
+            <artifactId>cpp</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -71,7 +77,7 @@
                     <pluginName>Sonar Crypto Plugin</pluginName>
                     <pluginClass>com.ibm.plugin.CryptographyPlugin</pluginClass>
                     <!-- This line must specify all file extensions which should be scanned by the plugin -->
-                    <requiredForLanguages>java,jsp,py,ipynb,go,cs</requiredForLanguages>
+                    <requiredForLanguages>java,jsp,py,ipynb,go,cs,c,cpp,h</requiredForLanguages>
                     <pluginApiMinVersion>${sonar.minVersion}</pluginApiMinVersion>
                     <sonarLintSupported>true</sonarLintSupported>
                     <skipDependenciesPackaging>true</skipDependenciesPackaging>
@@ -104,7 +110,7 @@
                                         <exclude>NOTICE*</exclude>
                                     </excludes>
                                 </filter>
-                            </filters>
+            </filters>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
hi @n1ckl0sk0rtge

This PR adds the base `CppTree` interface for upcoming C/C++ language support.

### Changes Included

- Added `CppTree.java` under `engine/src/main/java/com/ibm/engine/language/cpp/tree/`
- Introduced the base tree type used as the engine's `T` generic parameter for C/C++
- Added basic node metadata methods for kind, line, and column

### Purpose

`CppTree` provides the shared base interface for future C/C++ AST node types such as literals, identifiers, function calls, member access, and blocks.

