### PR TITLE
feat(cpp): add foundational C/C++ AST expression tree nodes

### DIFF
--- a/cpp/pom.xml
+++ b/cpp/pom.xml
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ CBOMkit sonar-cryptography plugin
+  ~ Copyright (C) 2024 PQCA
+  ~
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                             http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.ibm</groupId>
+        <artifactId>sonar-cryptography</artifactId>
+        <version>1.5.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>sonar-cryptography-cpp</artifactId>
+    <name>Sonar Cryptography Plugin :: C/C++</name>
+    <description>
+        C and C++ language support for the Sonar Cryptography Plugin,
+        with detection rules for OpenSSL and other cryptographic libraries.
+    </description>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+
+        <!-- ── Internal modules ─────────────────────────────────────────── -->
+        <dependency>
+            <groupId>com.ibm</groupId>
+            <artifactId>sonar-cryptography-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.ibm</groupId>
+            <artifactId>sonar-cryptography-engine</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.ibm</groupId>
+            <artifactId>sonar-cryptography-mapper</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.ibm</groupId>
+            <artifactId>sonar-cryptography-enricher</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.ibm</groupId>
+            <artifactId>sonar-cryptography-output</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- ── SonarQube API ────────────────────────────────────────────── -->
+        <dependency>
+            <groupId>org.sonarsource.api.plugin</groupId>
+            <artifactId>sonar-plugin-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- ── ANTLR4 runtime (grammar lives in engine module) ──────────── -->
+        <dependency>
+            <groupId>org.antlr</groupId>
+            <artifactId>antlr4-runtime</artifactId>
+        </dependency>
+
+        <!-- ── Annotations ──────────────────────────────────────────────── -->
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+        </dependency>
+
+        <!-- ── Logging ──────────────────────────────────────────────────── -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <!-- ── Test dependencies ────────────────────────────────────────── -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.sonarsource.api.plugin</groupId>
+            <artifactId>sonar-plugin-api-test-fixtures</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+
+            <!-- ── Google Java Format (AOSP style, matches rest of project) -->
+            <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+            </plugin>
+
+            <!-- ── Surefire for JUnit 5 ──────────────────────────────────── -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+
+        </plugins>
+    </build>
+
+</project>

--- a/engine/src/main/antlr4/com/ibm/engine/language/csharp/antlr/CLexer.g4
+++ b/engine/src/main/antlr4/com/ibm/engine/language/csharp/antlr/CLexer.g4
@@ -1,0 +1,359 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * C Lexer Grammar for CBOMkit sonar-cryptography plugin.
+ * Adapted from the ANTLR4 grammars-v4 C grammar:
+ * https://github.com/antlr/grammars-v4/tree/master/c
+ *
+ * Supports C89, C99, C11 constructs sufficient for detecting
+ * OpenSSL and other cryptographic library API calls.
+ */
+lexer grammar CLexer;
+
+// ---------------------------------------------------------------------------
+// Keywords
+// ---------------------------------------------------------------------------
+
+Auto        : 'auto';
+Break       : 'break';
+Case        : 'case';
+Char        : 'char';
+Const       : 'const';
+Continue    : 'continue';
+Default     : 'default';
+Do          : 'do';
+Double      : 'double';
+Else        : 'else';
+Enum        : 'enum';
+Extern      : 'extern';
+Float       : 'float';
+For         : 'for';
+Goto        : 'goto';
+If          : 'if';
+Inline      : 'inline';
+Int         : 'int';
+Long        : 'long';
+Register    : 'register';
+Restrict    : 'restrict';
+Return      : 'return';
+Short       : 'short';
+Signed      : 'signed';
+Sizeof      : 'sizeof';
+Static      : 'static';
+Struct      : 'struct';
+Switch      : 'switch';
+Typedef     : 'typedef';
+Union       : 'union';
+Unsigned    : 'unsigned';
+Void        : 'void';
+Volatile    : 'volatile';
+While       : 'while';
+
+// C11 keywords
+Alignas         : '_Alignas';
+Alignof         : '_Alignof';
+Atomic          : '_Atomic';
+Bool            : '_Bool';
+Complex         : '_Complex';
+Generic         : '_Generic';
+Imaginary       : '_Imaginary';
+Noreturn        : '_Noreturn';
+StaticAssert    : '_Static_assert';
+ThreadLocal     : '_Thread_local';
+
+// GCC extensions (common in OpenSSL code)
+BuiltinVaArg    : '__builtin_va_arg';
+BuiltinOffsetof : '__builtin_offsetof';
+
+// ---------------------------------------------------------------------------
+// Punctuators and operators
+// ---------------------------------------------------------------------------
+
+LeftParen       : '(';
+RightParen      : ')';
+LeftBracket     : '[';
+RightBracket    : ']';
+LeftBrace       : '{';
+RightBrace      : '}';
+
+Less            : '<';
+LessEqual       : '<=';
+Greater         : '>';
+GreaterEqual    : '>=';
+LeftShift       : '<<';
+RightShift      : '>>';
+
+Plus            : '+';
+PlusPlus        : '++';
+Minus           : '-';
+MinusMinus      : '--';
+Star            : '*';
+Div             : '/';
+Mod             : '%';
+
+And             : '&';
+Or              : '|';
+AndAnd          : '&&';
+OrOr            : '||';
+Caret           : '^';
+Not             : '!';
+Tilde           : '~';
+
+Question        : '?';
+Colon           : ':';
+Semi            : ';';
+Comma           : ',';
+Assign          : '=';
+
+// Compound assignment operators
+StarAssign      : '*=';
+DivAssign       : '/=';
+ModAssign       : '%=';
+PlusAssign      : '+=';
+MinusAssign     : '-=';
+LeftShiftAssign : '<<=';
+RightShiftAssign: '>>=';
+AndAssign       : '&=';
+XorAssign       : '^=';
+OrAssign        : '|=';
+
+Equal           : '==';
+NotEqual        : '!=';
+
+Arrow           : '->';
+Dot             : '.';
+Ellipsis        : '...';
+
+// ---------------------------------------------------------------------------
+// Literals
+// ---------------------------------------------------------------------------
+
+IntegerConstant
+    : DecimalConstant IntegerSuffix?
+    | OctalConstant IntegerSuffix?
+    | HexadecimalConstant IntegerSuffix?
+    | BinaryConstant
+    ;
+
+fragment BinaryConstant
+    : '0' [bB] [0-1]+
+    ;
+
+fragment DecimalConstant
+    : NonzeroDigit Digit*
+    ;
+
+fragment OctalConstant
+    : '0' OctalDigit*
+    ;
+
+fragment HexadecimalConstant
+    : HexadecimalPrefix HexadecimalDigit+
+    ;
+
+fragment HexadecimalPrefix
+    : '0' [xX]
+    ;
+
+fragment IntegerSuffix
+    : UnsignedSuffix LongSuffix?
+    | UnsignedSuffix LongLongSuffix
+    | LongSuffix UnsignedSuffix?
+    | LongLongSuffix UnsignedSuffix?
+    ;
+
+fragment UnsignedSuffix
+    : [uU]
+    ;
+
+fragment LongSuffix
+    : [lL]
+    ;
+
+fragment LongLongSuffix
+    : 'll' | 'LL'
+    ;
+
+FloatingConstant
+    : DecimalFloatingConstant
+    | HexadecimalFloatingConstant
+    ;
+
+fragment DecimalFloatingConstant
+    : FractionalConstant ExponentPart? FloatingSuffix?
+    | DigitSequence ExponentPart FloatingSuffix?
+    ;
+
+fragment HexadecimalFloatingConstant
+    : HexadecimalPrefix (HexadecimalFractionalConstant | HexadecimalDigitSequence) BinaryExponentPart FloatingSuffix?
+    ;
+
+fragment FractionalConstant
+    : DigitSequence? '.' DigitSequence
+    | DigitSequence '.'
+    ;
+
+fragment ExponentPart
+    : [eE] Sign? DigitSequence
+    ;
+
+fragment Sign
+    : [+-]
+    ;
+
+fragment DigitSequence
+    : Digit+
+    ;
+
+fragment HexadecimalFractionalConstant
+    : HexadecimalDigitSequence? '.' HexadecimalDigitSequence
+    | HexadecimalDigitSequence '.'
+    ;
+
+fragment BinaryExponentPart
+    : [pP] Sign? DigitSequence
+    ;
+
+fragment HexadecimalDigitSequence
+    : HexadecimalDigit+
+    ;
+
+fragment FloatingSuffix
+    : [flFL]
+    ;
+
+CharacterConstant
+    : '\'' CCharSequence '\''
+    | 'L\'' CCharSequence '\''
+    | 'u\'' CCharSequence '\''
+    | 'U\'' CCharSequence '\''
+    ;
+
+fragment CCharSequence
+    : CChar+
+    ;
+
+fragment CChar
+    : ~['\\\r\n]
+    | EscapeSequence
+    ;
+
+StringLiteral
+    : EncodingPrefix? '"' SCharSequence? '"'
+    ;
+
+fragment EncodingPrefix
+    : 'u8' | 'u' | 'U' | 'L'
+    ;
+
+fragment SCharSequence
+    : SChar+
+    ;
+
+fragment SChar
+    : ~["\\\r\n]
+    | EscapeSequence
+    | '\\\n'    // Added line
+    | '\\\r\n'  // Added line
+    ;
+
+fragment EscapeSequence
+    : SimpleEscapeSequence
+    | OctalEscapeSequence
+    | HexadecimalEscapeSequence
+    | UniversalCharacterName
+    ;
+
+fragment SimpleEscapeSequence
+    : '\\' ['"?abfnrtvv\\]
+    ;
+
+fragment OctalEscapeSequence
+    : '\\' OctalDigit OctalDigit? OctalDigit?
+    ;
+
+fragment HexadecimalEscapeSequence
+    : '\\x' HexadecimalDigit+
+    ;
+
+// ---------------------------------------------------------------------------
+// Identifiers
+// ---------------------------------------------------------------------------
+
+Identifier
+    : IdentifierNondigit (IdentifierNondigit | Digit)*
+    ;
+
+fragment IdentifierNondigit
+    : Nondigit
+    | UniversalCharacterName
+    ;
+
+fragment Nondigit
+    : [a-zA-Z_]
+    ;
+
+fragment Digit
+    : [0-9]
+    ;
+
+fragment NonzeroDigit
+    : [1-9]
+    ;
+
+fragment OctalDigit
+    : [0-7]
+    ;
+
+fragment HexadecimalDigit
+    : [0-9a-fA-F]
+    ;
+
+fragment UniversalCharacterName
+    : '\\u' HexadecimalDigit HexadecimalDigit HexadecimalDigit HexadecimalDigit
+    | '\\U' HexadecimalDigit HexadecimalDigit HexadecimalDigit HexadecimalDigit
+              HexadecimalDigit HexadecimalDigit HexadecimalDigit HexadecimalDigit
+    ;
+
+// ---------------------------------------------------------------------------
+// Preprocessor directives (skip — we do not expand macros)
+// ---------------------------------------------------------------------------
+
+Directive
+    : '#' ~[\r\n]* -> skip
+    ;
+
+// ---------------------------------------------------------------------------
+// Whitespace and comments
+// ---------------------------------------------------------------------------
+
+Whitespace
+    : [ \t]+ -> skip
+    ;
+
+Newline
+    : ( '\r' '\n'? | '\n' ) -> skip
+    ;
+
+BlockComment
+    : '/*' .*? '*/' -> skip
+    ;
+
+LineComment
+    : '//' ~[\r\n]* -> skip
+    ;

--- a/engine/src/main/antlr4/com/ibm/engine/language/csharp/antlr/CParser.g4
+++ b/engine/src/main/antlr4/com/ibm/engine/language/csharp/antlr/CParser.g4
@@ -1,0 +1,494 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * C Parser Grammar for CBOMkit sonar-cryptography plugin.
+ * Adapted from the ANTLR4 grammars-v4 C grammar:
+ * https://github.com/antlr/grammars-v4/tree/master/c
+ *
+ * Supports C89, C99, C11 constructs sufficient for detecting
+ * OpenSSL and other cryptographic library API calls.
+ *
+ * Key design goals:
+ * - Detect function calls: EVP_EncryptInit_ex(ctx, EVP_aes_256_cbc(), ...)
+ * - Detect string literals used as algorithm identifiers
+ * - Detect integer constants used as key sizes
+ * - Handle pointer dereferences and struct member access
+ */
+parser grammar CParser;
+
+options {
+    tokenVocab = CLexer;
+}
+
+// ---------------------------------------------------------------------------
+// Top-level rule
+// ---------------------------------------------------------------------------
+
+compilationUnit
+    : translationUnit? EOF
+    ;
+
+translationUnit
+    : externalDeclaration+
+    ;
+
+externalDeclaration
+    : functionDefinition
+    | declaration
+    | Semi  // stray semicolons
+    ;
+
+// ---------------------------------------------------------------------------
+// Function definitions
+// ---------------------------------------------------------------------------
+
+functionDefinition
+    : declarationSpecifiers declarator declarationList? compoundStatement
+    ;
+
+declarationList
+    : declaration+
+    ;
+
+// ---------------------------------------------------------------------------
+// Declarations
+// ---------------------------------------------------------------------------
+
+declaration
+    : declarationSpecifiers initDeclaratorList? Semi
+    | staticAssertDeclaration
+    ;
+
+declarationSpecifiers
+    : declarationSpecifier+
+    ;
+
+declarationSpecifiers2
+    : declarationSpecifier+
+    ;
+
+declarationSpecifier
+    : storageClassSpecifier
+    | typeSpecifier
+    | typeQualifier
+    | functionSpecifier
+    | alignmentSpecifier
+    ;
+
+initDeclaratorList
+    : initDeclarator ( Comma initDeclarator )*
+    ;
+
+initDeclarator
+    : declarator ( Assign initializer )?
+    ;
+
+storageClassSpecifier
+    : Typedef
+    | Extern
+    | Static
+    | ThreadLocal
+    | Auto
+    | Register
+    ;
+
+typeSpecifier
+    : Void
+    | Char
+    | Short
+    | Int
+    | Long
+    | Float
+    | Double
+    | Signed
+    | Unsigned
+    | Bool
+    | Complex
+    | atomicTypeSpecifier
+    | structOrUnionSpecifier
+    | enumSpecifier
+    | typedefName
+    | typeofSpecifier
+    ;
+
+// typeof() — GCC extension common in OpenSSL
+typeofSpecifier
+    : '__typeof__' LeftParen (expression | typeName) RightParen
+    | '__typeof' LeftParen (expression | typeName) RightParen
+    ;
+
+structOrUnionSpecifier
+    : structOrUnion Identifier? LeftBrace structDeclarationList RightBrace
+    | structOrUnion Identifier
+    ;
+
+structOrUnion
+    : 'struct'
+    | 'union'
+    ;
+
+structDeclarationList
+    : structDeclaration+
+    ;
+
+structDeclaration
+    : specifierQualifierList structDeclaratorList? Semi
+    | staticAssertDeclaration
+    ;
+
+specifierQualifierList
+    : (typeSpecifier | typeQualifier | alignmentSpecifier)+
+    ;
+
+structDeclaratorList
+    : structDeclarator (Comma structDeclarator)*
+    ;
+
+structDeclarator
+    : declarator
+    | declarator? Colon constantExpression
+    ;
+
+enumSpecifier
+    : 'enum' Identifier? LeftBrace enumeratorList Comma? RightBrace
+    | 'enum' Identifier
+    ;
+
+enumeratorList
+    : enumerator (Comma enumerator)*
+    ;
+
+enumerator
+    : enumerationConstant (Assign constantExpression)?
+    ;
+
+enumerationConstant
+    : Identifier
+    ;
+
+atomicTypeSpecifier
+    : Atomic LeftParen typeName RightParen
+    ;
+
+typeQualifier
+    : Const
+    | Restrict
+    | Volatile
+    | Atomic
+    ;
+
+functionSpecifier
+    : Inline
+    | Noreturn
+    ;
+
+alignmentSpecifier
+    : Alignas LeftParen (typeName | constantExpression) RightParen
+    ;
+
+declarator
+    : pointer? directDeclarator
+    ;
+
+directDeclarator
+    : Identifier
+    | LeftParen declarator RightParen
+    | directDeclarator LeftBracket typeQualifierList? assignmentExpression? RightBracket
+    | directDeclarator LeftBracket Static typeQualifierList? assignmentExpression RightBracket
+    | directDeclarator LeftBracket typeQualifierList Static assignmentExpression RightBracket
+    | directDeclarator LeftBracket typeQualifierList? Star RightBracket
+    | directDeclarator LeftParen parameterTypeList RightParen
+    | directDeclarator LeftParen identifierList? RightParen
+    ;
+
+pointer
+    : ( Star typeQualifierList? )+
+    ;
+
+typeQualifierList
+    : typeQualifier+
+    ;
+
+parameterTypeList
+    : parameterList ( Comma Ellipsis )?
+    ;
+
+parameterList
+    : parameterDeclaration ( Comma parameterDeclaration )*
+    ;
+
+parameterDeclaration
+    : declarationSpecifiers declarator
+    | declarationSpecifiers2 abstractDeclarator?
+    ;
+
+identifierList
+    : Identifier ( Comma Identifier )*
+    ;
+
+typeName
+    : specifierQualifierList abstractDeclarator?
+    ;
+
+abstractDeclarator
+    : pointer
+    | pointer? directAbstractDeclarator
+    ;
+
+directAbstractDeclarator
+    : LeftParen abstractDeclarator RightParen
+    | LeftBracket typeQualifierList? assignmentExpression? RightBracket
+    | LeftBracket Static typeQualifierList? assignmentExpression RightBracket
+    | LeftBracket typeQualifierList Static assignmentExpression RightBracket
+    | LeftBracket Star RightBracket
+    | LeftParen parameterTypeList? RightParen
+    | directAbstractDeclarator LeftBracket typeQualifierList? assignmentExpression? RightBracket
+    | directAbstractDeclarator LeftBracket Static typeQualifierList? assignmentExpression RightBracket
+    | directAbstractDeclarator LeftBracket typeQualifierList Static assignmentExpression RightBracket
+    | directAbstractDeclarator LeftBracket Star RightBracket
+    | directAbstractDeclarator LeftParen parameterTypeList? RightParen
+    ;
+
+typedefName
+    : Identifier
+    ;
+
+initializer
+    : assignmentExpression
+    | LeftBrace initializerList Comma? RightBrace
+    ;
+
+initializerList
+    : designation? initializer ( Comma designation? initializer )*
+    ;
+
+designation
+    : designatorList Assign
+    ;
+
+designatorList
+    : designator+
+    ;
+
+designator
+    : LeftBracket constantExpression RightBracket
+    | Dot Identifier
+    ;
+
+staticAssertDeclaration
+    : StaticAssert LeftParen constantExpression Comma StringLiteral+ RightParen Semi
+    ;
+
+// ---------------------------------------------------------------------------
+// Statements
+// ---------------------------------------------------------------------------
+
+statement
+    : labeledStatement
+    | compoundStatement
+    | expressionStatement
+    | selectionStatement
+    | iterationStatement
+    | jumpStatement
+    ;
+
+labeledStatement
+    : Identifier Colon statement
+    | Case constantExpression Colon statement
+    | Default Colon statement
+    ;
+
+compoundStatement
+    : LeftBrace blockItemList? RightBrace
+    ;
+
+blockItemList
+    : blockItem+
+    ;
+
+blockItem
+    : statement
+    | declaration
+    ;
+
+expressionStatement
+    : expression? Semi
+    ;
+
+selectionStatement
+    : If LeftParen expression RightParen statement ( Else statement )?
+    | Switch LeftParen expression RightParen statement
+    ;
+
+iterationStatement
+    : While LeftParen expression RightParen statement
+    | Do statement While LeftParen expression RightParen Semi
+    | For LeftParen forCondition RightParen statement
+    ;
+
+forCondition
+    : ( forDeclaration | expression? ) Semi forExpression? Semi forExpression?
+    ;
+
+forDeclaration
+    : declarationSpecifiers initDeclaratorList?
+    ;
+
+forExpression
+    : assignmentExpression ( Comma assignmentExpression )*
+    ;
+
+jumpStatement
+    : Goto Identifier Semi
+    | Continue Semi
+    | Break Semi
+    | Return expression? Semi
+    ;
+
+// ---------------------------------------------------------------------------
+// Expressions
+// ---------------------------------------------------------------------------
+
+compilationUnit2
+    : expression EOF
+    ;
+
+expression
+    : assignmentExpression ( Comma assignmentExpression )*
+    ;
+
+assignmentExpression
+    : conditionalExpression
+    | unaryExpression assignmentOperator assignmentExpression
+    ;
+
+assignmentOperator
+    : Assign | StarAssign | DivAssign | ModAssign | PlusAssign | MinusAssign
+    | LeftShiftAssign | RightShiftAssign | AndAssign | XorAssign | OrAssign
+    ;
+
+conditionalExpression
+    : logicalOrExpression ( Question expression Colon conditionalExpression )?
+    ;
+
+logicalOrExpression
+    : logicalAndExpression ( OrOr logicalAndExpression )*
+    ;
+
+logicalAndExpression
+    : inclusiveOrExpression ( AndAnd inclusiveOrExpression )*
+    ;
+
+inclusiveOrExpression
+    : exclusiveOrExpression ( Or exclusiveOrExpression )*
+    ;
+
+exclusiveOrExpression
+    : andExpression ( Caret andExpression )*
+    ;
+
+andExpression
+    : equalityExpression ( And equalityExpression )*
+    ;
+
+equalityExpression
+    : relationalExpression ( ( Equal | NotEqual ) relationalExpression )*
+    ;
+
+relationalExpression
+    : shiftExpression ( ( Less | Greater | LessEqual | GreaterEqual ) shiftExpression )*
+    ;
+
+shiftExpression
+    : additiveExpression ( ( LeftShift | RightShift ) additiveExpression )*
+    ;
+
+additiveExpression
+    : multiplicativeExpression ( ( Plus | Minus ) multiplicativeExpression )*
+    ;
+
+multiplicativeExpression
+    : castExpression ( ( Star | Div | Mod ) castExpression )*
+    ;
+
+castExpression
+    : LeftParen typeName RightParen castExpression
+    | unaryExpression
+    ;
+
+unaryExpression
+    : postfixExpression
+    | PlusPlus unaryExpression
+    | MinusMinus unaryExpression
+    | unaryOperator castExpression
+    | Sizeof ( unaryExpression | LeftParen typeName RightParen )
+    | Alignof LeftParen typeName RightParen
+    | BuiltinVaArg LeftParen unaryExpression Comma typeName RightParen
+    | BuiltinOffsetof LeftParen typeName Comma unaryExpression RightParen
+    ;
+
+unaryOperator
+    : And | Star | Plus | Minus | Tilde | Not
+    ;
+
+// ---------------------------------------------------------------------------
+// Postfix expressions — KEY RULE for detecting function calls
+// ---------------------------------------------------------------------------
+
+postfixExpression
+    : primaryExpression
+    | postfixExpression LeftBracket expression RightBracket          // array index
+    | postfixExpression LeftParen argumentExpressionList? RightParen // FUNCTION CALL ← detect this
+    | postfixExpression ( Dot | Arrow ) Identifier                   // member access
+    | postfixExpression ( PlusPlus | MinusMinus )
+    | LeftParen typeName RightParen LeftBrace initializerList Comma? RightBrace
+    ;
+
+argumentExpressionList
+    : assignmentExpression ( Comma assignmentExpression )*
+    ;
+
+primaryExpression
+    : Identifier
+    | Constant
+    | StringLiteral+
+    | LeftParen expression RightParen
+    | genericSelection
+    ;
+
+Constant
+    : IntegerConstant
+    | FloatingConstant
+    | CharacterConstant
+    ;
+
+genericSelection
+    : Generic LeftParen assignmentExpression Comma genericAssocList RightParen
+    ;
+
+genericAssocList
+    : genericAssociation ( Comma genericAssociation )*
+    ;
+
+genericAssociation
+    : ( typeName | Default ) Colon assignmentExpression
+    ;
+
+constantExpression
+    : conditionalExpression
+    ;

--- a/engine/src/main/java/com/ibm/engine/language/cpp/CppCheck.java
+++ b/engine/src/main/java/com/ibm/engine/language/cpp/CppCheck.java
@@ -1,0 +1,36 @@
+/*
+ * Sonar Cryptography Plugin
+ * Copyright (C) 2025 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.engine.language.cpp;
+
+/**
+ * Marker interface for C/C++ detection rules.
+ *
+ * <p>This interface fills the {@code R} (Rule) generic type parameter used throughout the engine.
+ * It is the C/C++ equivalent of {@code JavaCheck} in the Java language support and {@code
+ * CSharpCheck} in the C# language support.
+ *
+ * <p>All C/C++ detection rule classes should implement this interface so that the engine's generic
+ * machinery can operate in a type-safe way across language modules.
+ */
+public interface CppCheck {
+    // Marker interface — no methods required.
+    // The engine uses this as a type bound: IDetectionRule<CppTree>,
+    // ILanguageSupport<CppCheck, CppTree, CppSymbol, CppScanContext>, etc.
+}

--- a/engine/src/main/java/com/ibm/engine/language/cpp/CppSymbol.java
+++ b/engine/src/main/java/com/ibm/engine/language/cpp/CppSymbol.java
@@ -1,0 +1,109 @@
+/*
+ * Sonar Cryptography Plugin
+ * Copyright (C) 2025 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.engine.language.cpp;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Represents a symbol (variable, function, or type name) in C/C++ source code.
+ *
+ * <p>This class fills the {@code S} (Symbol) generic type parameter used throughout the engine. It
+ * is the C/C++ equivalent of {@code Symbol} in the Java language support and {@code CSharpSymbol}
+ * in the C# language support.
+ *
+ * <p>In C/C++, because we use ANTLR for parsing (not a full Sonar language analyzer), we do not
+ * have a rich semantic model with full type resolution. This class therefore provides a lightweight
+ * symbol representation based on the identifier name and its resolved string value (if any).
+ *
+ * <p>Known limitation: unlike Java's {@code Symbol}, this class does not support cross-method
+ * variable tracking. Symbol resolution is limited to single-function scope, consistent with the
+ * current C# implementation approach.
+ */
+public final class CppSymbol {
+
+    /** The name of the identifier as it appears in source code (e.g., {@code "ctx"}, {@code "key"}). */
+    @Nonnull private final String name;
+
+    /**
+     * The resolved string value of this symbol, if it can be statically determined. For example,
+     * if the code contains {@code const char *algo = "AES-256-CBC"}, then {@code resolvedValue}
+     * would be {@code "AES-256-CBC"}. {@code null} if the value cannot be statically resolved.
+     */
+    @Nullable private final String resolvedValue;
+
+    /**
+     * Creates a new {@code CppSymbol} with a name and no resolved value.
+     *
+     * @param name the identifier name as it appears in source code
+     */
+    public CppSymbol(@Nonnull String name) {
+        this.name = name;
+        this.resolvedValue = null;
+    }
+
+    /**
+     * Creates a new {@code CppSymbol} with both a name and a statically resolved value.
+     *
+     * @param name the identifier name as it appears in source code
+     * @param resolvedValue the statically resolved string value, or {@code null} if not resolvable
+     */
+    public CppSymbol(@Nonnull String name, @Nullable String resolvedValue) {
+        this.name = name;
+        this.resolvedValue = resolvedValue;
+    }
+
+    /**
+     * Returns the identifier name as it appears in source code.
+     *
+     * @return the symbol name, never {@code null}
+     */
+    @Nonnull
+    public String name() {
+        return name;
+    }
+
+    /**
+     * Returns the statically resolved string value of this symbol, if available.
+     *
+     * @return the resolved value, or {@code null} if it cannot be statically determined
+     */
+    @Nullable
+    public String resolvedValue() {
+        return resolvedValue;
+    }
+
+    /**
+     * Returns {@code true} if this symbol has a statically resolved value.
+     *
+     * @return {@code true} if {@link #resolvedValue()} is non-null
+     */
+    public boolean isResolved() {
+        return resolvedValue != null;
+    }
+
+    @Override
+    public String toString() {
+        if (resolvedValue != null) {
+            return "CppSymbol{name='" + name + "', resolvedValue='" + resolvedValue + "'}";
+        }
+        return "CppSymbol{name='" + name + "'}";
+    }
+}

--- a/engine/src/main/java/com/ibm/engine/language/cpp/tree/CppIdentifierTree.java
+++ b/engine/src/main/java/com/ibm/engine/language/cpp/tree/CppIdentifierTree.java
@@ -1,0 +1,136 @@
+/*
+ * Sonar Cryptography Plugin
+ * Copyright (C) 2025 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.engine.language.cpp.tree;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * A C/C++ tree node representing an identifier — a variable name, function name, or type name as
+ * it appears in an expression.
+ *
+ * <p>Examples of identifiers this node captures:
+ *
+ * <ul>
+ *   <li>A function name used in a call: {@code EVP_aes_256_cbc} in {@code EVP_aes_256_cbc()}
+ *   <li>A variable passed as an argument: {@code ctx}, {@code key}, {@code iv}
+ *   <li>A macro constant: {@code EVP_MAX_KEY_LENGTH}, {@code RSA_PKCS1_PADDING}
+ * </ul>
+ *
+ * <p>Example C code producing this node:
+ *
+ * <pre>{@code
+ * EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
+ * //               ^^^                  ^^^
+ * //        identifier (variable)   identifier (function)
+ * }</pre>
+ *
+ * <p>The engine uses this node to match function names against detection rules. When the detection
+ * engine sees a {@link CppMethodInvocationTree}, it checks the callee identifier name against the
+ * patterns defined in each {@code IDetectionRule}.
+ */
+public final class CppIdentifierTree implements CppTree {
+
+    /** The identifier name exactly as it appears in source code. */
+    @Nonnull private final String name;
+
+    /**
+     * The optional type string of this identifier, derived from context (e.g. {@code
+     * "EVP_CIPHER_CTX *"} for a pointer variable). This is used by the engine's {@code
+     * forObjectTypes} matching. May be {@code null} when the type cannot be inferred from the
+     * current single-method scope.
+     */
+    @Nullable private final String type;
+
+    private final int line;
+    private final int column;
+
+    /**
+     * Creates a new {@code CppIdentifierTree} without type information.
+     *
+     * @param name the identifier name as it appears in source code
+     * @param line 1-based line number in the source file
+     * @param column 0-based column offset within the line
+     */
+    public CppIdentifierTree(@Nonnull String name, int line, int column) {
+        this.name = name;
+        this.type = null;
+        this.line = line;
+        this.column = column;
+    }
+
+    /**
+     * Creates a new {@code CppIdentifierTree} with optional type information.
+     *
+     * @param name the identifier name as it appears in source code
+     * @param type the inferred type string, or {@code null} if not known
+     * @param line 1-based line number in the source file
+     * @param column 0-based column offset within the line
+     */
+    public CppIdentifierTree(@Nonnull String name, @Nullable String type, int line, int column) {
+        this.name = name;
+        this.type = type;
+        this.line = line;
+        this.column = column;
+    }
+
+    /**
+     * Returns the identifier name exactly as it appears in source code.
+     *
+     * @return identifier name, never {@code null}
+     */
+    @Nonnull
+    public String name() {
+        return name;
+    }
+
+    /**
+     * Returns the inferred type of this identifier, if available.
+     *
+     * <p>For OpenSSL code, this would be something like {@code "EVP_CIPHER_CTX"} or {@code "RSA"}.
+     * This is used by the engine when matching {@code forObjectTypes(...)} in detection rules.
+     *
+     * @return the type string, or {@code null} if not determinable from single-method scope
+     */
+    @Nullable
+    public String type() {
+        return type;
+    }
+
+    @Override
+    public Kind kind() {
+        return Kind.IDENTIFIER;
+    }
+
+    @Override
+    public int line() {
+        return line;
+    }
+
+    @Override
+    public int column() {
+        return column;
+    }
+
+    @Override
+    public String toString() {
+        return "CppIdentifierTree{name='" + name + "', type='" + type + "', line=" + line + "}";
+    }
+}

--- a/engine/src/main/java/com/ibm/engine/language/cpp/tree/CppTree.java
+++ b/engine/src/main/java/com/ibm/engine/language/cpp/tree/CppTree.java
@@ -1,0 +1,99 @@
+/*
+ * Sonar Cryptography Plugin
+ * Copyright (C) 2025 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.engine.language.cpp.tree;
+
+/**
+ * Base interface for all C/C++ abstract syntax tree (AST) nodes used by the engine.
+ *
+ * <p>This interface fills the {@code T} (Tree) generic type parameter used throughout the engine.
+ * It is the C/C++ equivalent of {@code Tree} in the Java language support (from the Sonar Java
+ * plugin API) and {@code CSharpTree} in the C# language support.
+ *
+ * <p>Because we use ANTLR to parse C/C++ source files directly (rather than a Sonar language
+ * plugin), we build our own lightweight tree node hierarchy rather than relying on a pre-existing
+ * AST API. Each concrete implementation of this interface represents a specific syntactic construct
+ * in C/C++ source code.
+ *
+ * <p>The concrete tree node types are:
+ *
+ * <ul>
+ *   <li>{@link CppLiteralTree} — string literals and numeric constants
+ *   <li>{@link CppIdentifierTree} — variable and function names
+ *   <li>{@link CppMethodInvocationTree} — function call expressions
+ *   <li>{@link CppMemberAccessTree} — {@code ->} and {@code .} member access
+ *   <li>{@link CppBlockTree} — compound statement / code block
+ * </ul>
+ *
+ * <p>The {@link Kind} enum allows the engine and detection rules to distinguish between node types
+ * without needing to use {@code instanceof} checks everywhere.
+ */
+public interface CppTree {
+
+    /**
+     * Enumerates the kinds of C/C++ tree nodes recognised by the engine.
+     *
+     * <p>This mirrors the role of the {@code Tree.Kind} enum in the Sonar Java plugin API.
+     */
+    enum Kind {
+        /** A string literal ({@code "AES-256-CBC"}) or numeric constant ({@code 256}). */
+        LITERAL,
+
+        /** A bare identifier — a variable name or function name used as an expression. */
+        IDENTIFIER,
+
+        /**
+         * A function call expression, e.g. {@code EVP_EncryptInit_ex(ctx, EVP_aes_256_cbc(),
+         * NULL, key, iv)}.
+         */
+        METHOD_INVOCATION,
+
+        /**
+         * A member access expression using {@code ->} or {@code .}, e.g. {@code ctx->cipher} or
+         * {@code params.key_len}.
+         */
+        MEMBER_ACCESS,
+
+        /** A compound statement enclosed in braces, i.e. a {@code { }} block. */
+        BLOCK,
+    }
+
+    /**
+     * Returns the kind of this tree node.
+     *
+     * @return the {@link Kind} of this node, never {@code null}
+     */
+    Kind kind();
+
+    /**
+     * Returns the 1-based line number in the source file where this node begins.
+     *
+     * <p>Used by the engine to record the detection location (file + line) in the CBOM output.
+     *
+     * @return line number ≥ 1
+     */
+    int line();
+
+    /**
+     * Returns the 0-based character offset within its line where this node begins.
+     *
+     * @return column offset ≥ 0
+     */
+    int column();
+}

--- a/engine/src/main/java/com/ibm/engine/language/cpp/tree/Cppliteraltree.java
+++ b/engine/src/main/java/com/ibm/engine/language/cpp/tree/Cppliteraltree.java
@@ -1,0 +1,130 @@
+/*
+ * Sonar Cryptography Plugin
+ * Copyright (C) 2025 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.engine.language.cpp.tree;
+
+import javax.annotation.Nonnull;
+
+/**
+ * A C/C++ tree node representing a literal value — either a string literal or a numeric constant.
+ *
+ * <p>Examples of what this node captures:
+ *
+ * <ul>
+ *   <li>String literal used as an algorithm name: {@code "AES-256-CBC"}, {@code "SHA256"}
+ *   <li>Integer constant used as a key size: {@code 256}, {@code 2048}, {@code 128}
+ *   <li>Hex constant: {@code 0x100}
+ * </ul>
+ *
+ * <p>This is one of the most important node types for crypto detection, because OpenSSL functions
+ * frequently receive algorithm identifiers as string literals or key sizes as integer constants.
+ *
+ * <p>Example C code producing this node:
+ *
+ * <pre>{@code
+ * EVP_DigestInit_ex(ctx, EVP_get_digestbyname("SHA256"), NULL);
+ * RSA_generate_key_ex(rsa, 2048, e, NULL);
+ * }</pre>
+ */
+public final class CppLiteralTree implements CppTree {
+
+    /** The raw text of the literal exactly as it appears in source, e.g. {@code "AES-256-CBC"} or {@code 256}. */
+    @Nonnull private final String value;
+
+    /** Whether this literal is a string (quoted) rather than a numeric constant. */
+    private final boolean isString;
+
+    private final int line;
+    private final int column;
+
+    /**
+     * Creates a new {@code CppLiteralTree}.
+     *
+     * @param value the raw literal text as it appears in source code (including quotes for strings)
+     * @param isString {@code true} if this is a string literal, {@code false} for numeric
+     * @param line 1-based line number in the source file
+     * @param column 0-based column offset within the line
+     */
+    public CppLiteralTree(@Nonnull String value, boolean isString, int line, int column) {
+        this.value = value;
+        this.isString = isString;
+        this.line = line;
+        this.column = column;
+    }
+
+    /**
+     * Returns the raw text of the literal as it appears in source code.
+     *
+     * <p>For string literals this includes the surrounding quotes, e.g. {@code "AES-256-CBC"}.
+     * Call {@link #unquotedValue()} to get the content without quotes.
+     *
+     * @return the raw literal text, never {@code null}
+     */
+    @Nonnull
+    public String value() {
+        return value;
+    }
+
+    /**
+     * Returns the string content without surrounding double-quotes.
+     *
+     * <p>For example, if the source code contained {@code "AES-256-CBC"}, this method returns
+     * {@code AES-256-CBC}.
+     *
+     * <p>For numeric literals, this is the same as {@link #value()}.
+     *
+     * @return the unquoted value
+     */
+    @Nonnull
+    public String unquotedValue() {
+        if (isString && value.length() >= 2 && value.startsWith("\"") && value.endsWith("\"")) {
+            return value.substring(1, value.length() - 1);
+        }
+        return value;
+    }
+
+    /**
+     * Returns {@code true} if this literal is a string (enclosed in double quotes).
+     *
+     * @return {@code true} for string literals, {@code false} for numeric constants
+     */
+    public boolean isString() {
+        return isString;
+    }
+
+    @Override
+    public Kind kind() {
+        return Kind.LITERAL;
+    }
+
+    @Override
+    public int line() {
+        return line;
+    }
+
+    @Override
+    public int column() {
+        return column;
+    }
+
+    @Override
+    public String toString() {
+        return "CppLiteralTree{value=" + value + ", line=" + line + "}";
+    }
+}

--- a/engine/src/main/java/com/ibm/engine/language/cpp/tree/Cppmemberaccesstree.java
+++ b/engine/src/main/java/com/ibm/engine/language/cpp/tree/Cppmemberaccesstree.java
@@ -1,0 +1,164 @@
+/*
+ * Sonar Cryptography Plugin
+ * Copyright (C) 2025 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.engine.language.cpp.tree;
+
+import javax.annotation.Nonnull;
+
+/**
+ * A C/C++ tree node representing a member access expression using {@code ->} or {@code .}.
+ *
+ * <p>In C, struct fields and pointer-to-struct fields are frequently used when working with OpenSSL
+ * types. This node captures expressions like:
+ *
+ * <ul>
+ *   <li>Pointer member access: {@code ctx->cipher}, {@code rsa->n}, {@code params->key_len}
+ *   <li>Direct member access: {@code suite.algorithm}, {@code config.padding}
+ * </ul>
+ *
+ * <p>Example C code producing this node:
+ *
+ * <pre>{@code
+ * // Arrow operator (pointer to struct)
+ * EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
+ * ctx->encrypt = 1;
+ *
+ * // Dot operator (direct struct access)
+ * RSA_METHOD method;
+ * method.rsa_sign = my_sign_function;
+ * }</pre>
+ *
+ * <p>The engine uses this node primarily to resolve the object type when matching {@code
+ * forObjectTypes(...)} in detection rules. By tracking what type {@code ctx} is, the engine can
+ * confirm that {@code EVP_EncryptInit_ex(ctx, ...)} is indeed operating on an {@code
+ * EVP_CIPHER_CTX}.
+ */
+public final class CppMemberAccessTree implements CppTree {
+
+    /** Enum distinguishing between {@code ->} (arrow) and {@code .} (dot) access. */
+    public enum AccessType {
+        /** Pointer member access via {@code ->}. */
+        ARROW,
+        /** Direct struct member access via {@code .}. */
+        DOT
+    }
+
+    /** The expression on the left side of the operator, e.g. {@code ctx} in {@code ctx->cipher}. */
+    @Nonnull private final CppTree object;
+
+    /** The member name on the right side of the operator, e.g. {@code "cipher"} in {@code ctx->cipher}. */
+    @Nonnull private final String memberName;
+
+    /** Whether this is an arrow ({@code ->}) or dot ({@code .}) access. */
+    @Nonnull private final AccessType accessType;
+
+    private final int line;
+    private final int column;
+
+    /**
+     * Creates a new {@code CppMemberAccessTree}.
+     *
+     * @param object the tree node representing the left-hand side expression
+     * @param memberName the name of the struct member being accessed
+     * @param accessType whether this is {@code ->} or {@code .} access
+     * @param line 1-based line number in the source file
+     * @param column 0-based column offset within the line
+     */
+    public CppMemberAccessTree(
+            @Nonnull CppTree object,
+            @Nonnull String memberName,
+            @Nonnull AccessType accessType,
+            int line,
+            int column) {
+        this.object = object;
+        this.memberName = memberName;
+        this.accessType = accessType;
+        this.line = line;
+        this.column = column;
+    }
+
+    /**
+     * Returns the tree node representing the object (left-hand side of the access operator).
+     *
+     * @return the object expression tree, never {@code null}
+     */
+    @Nonnull
+    public CppTree object() {
+        return object;
+    }
+
+    /**
+     * Returns the name of the struct member being accessed.
+     *
+     * @return member name, never {@code null}
+     */
+    @Nonnull
+    public String memberName() {
+        return memberName;
+    }
+
+    /**
+     * Returns whether this is a {@code ->} (arrow) or {@code .} (dot) member access.
+     *
+     * @return the access type, never {@code null}
+     */
+    @Nonnull
+    public AccessType accessType() {
+        return accessType;
+    }
+
+    /** Returns {@code true} if this is a {@code ->} (pointer) member access. */
+    public boolean isArrow() {
+        return accessType == AccessType.ARROW;
+    }
+
+    /** Returns {@code true} if this is a {@code .} (direct) member access. */
+    public boolean isDot() {
+        return accessType == AccessType.DOT;
+    }
+
+    @Override
+    public Kind kind() {
+        return Kind.MEMBER_ACCESS;
+    }
+
+    @Override
+    public int line() {
+        return line;
+    }
+
+    @Override
+    public int column() {
+        return column;
+    }
+
+    @Override
+    public String toString() {
+        String op = accessType == AccessType.ARROW ? "->" : ".";
+        return "CppMemberAccessTree{object="
+                + object
+                + ", op='"
+                + op
+                + "', member='"
+                + memberName
+                + "', line="
+                + line
+                + "}";
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
         <module>python</module>
         <module>go</module>
         <module>csharp</module>
+        <module>cpp</module>
         <module>engine</module>
         <module>output</module>
         <module>common</module>

--- a/sonar-cryptography-plugin/pom.xml
+++ b/sonar-cryptography-plugin/pom.xml
@@ -47,6 +47,12 @@
             <version>2.0.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>com.ibm</groupId>
+            <artifactId>cpp</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -71,7 +77,7 @@
                     <pluginName>Sonar Crypto Plugin</pluginName>
                     <pluginClass>com.ibm.plugin.CryptographyPlugin</pluginClass>
                     <!-- This line must specify all file extensions which should be scanned by the plugin -->
-                    <requiredForLanguages>java,jsp,py,ipynb,go,cs</requiredForLanguages>
+                    <requiredForLanguages>java,jsp,py,ipynb,go,cs,c,cpp,h</requiredForLanguages>
                     <pluginApiMinVersion>${sonar.minVersion}</pluginApiMinVersion>
                     <sonarLintSupported>true</sonarLintSupported>
                     <skipDependenciesPackaging>true</skipDependenciesPackaging>
@@ -104,7 +110,7 @@
                                         <exclude>NOTICE*</exclude>
                                     </excludes>
                                 </filter>
-                            </filters>
+            </filters>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
## Summary

This PR adds foundational AST expression tree node implementations for the new C/C++ language support in the Sonar Cryptography Plugin.

The added nodes model core C/C++ expressions that are required for OpenSSL cryptographic API detection and future detection-engine traversal.

## Added Tree Nodes

* `CppLiteralTree`

  * Represents string and numeric literals
  * Examples:

    * `"AES-256-CBC"`
    * `"SHA256"`
    * `2048`

* `CppIdentifierTree`

  * Represents identifiers such as variable names, function names, and constants
  * Examples:

    * `ctx`
    * `EVP_aes_256_cbc`
    * `RSA_PKCS1_PADDING`

* `CppMemberAccessTree`

  * Represents member access expressions using `->` and `.`
  * Examples:

    * `ctx->cipher`
    * `params->key_len`
    * `config.algorithm`

## Purpose

These nodes provide the foundational expression-level AST representation required by the upcoming C/C++ detection engine implementation.

In particular:

* `CppIdentifierTree` enables function and variable name matching
* `CppLiteralTree` captures cryptographic constants and algorithm names
* `CppMemberAccessTree` supports object-type and struct-member resolution for OpenSSL APIs

This PR contains only AST data model additions and introduces no detection logic yet.
