### PR TITLE
feat(java): add Google Tink AEAD detection rules

### DIFF
--- a/csharp/src/main/java/com/ibm/plugin/rules/detection/CSharpDetectionRules.java
+++ b/csharp/src/main/java/com/ibm/plugin/rules/detection/CSharpDetectionRules.java
@@ -27,6 +27,7 @@ import com.ibm.plugin.rules.detection.dotnet.DotNetDSA;
 import com.ibm.plugin.rules.detection.dotnet.DotNetECDiffieHellman;
 import com.ibm.plugin.rules.detection.dotnet.DotNetECDsa;
 import com.ibm.plugin.rules.detection.dotnet.DotNetHMAC;
+import com.ibm.plugin.rules.detection.dotnet.DotNetMLKem;
 import com.ibm.plugin.rules.detection.dotnet.DotNetRC2;
 import com.ibm.plugin.rules.detection.dotnet.DotNetRSA;
 import com.ibm.plugin.rules.detection.dotnet.DotNetRfc2898DeriveBytes;
@@ -56,7 +57,8 @@ public final class CSharpDetectionRules {
                         DotNetDSA.rules().stream(),
                         DotNetSHA.rules().stream(),
                         DotNetHMAC.rules().stream(),
-                        DotNetRfc2898DeriveBytes.rules().stream())
+                        DotNetRfc2898DeriveBytes.rules().stream(),
+                        DotNetMLKem.rules().stream())
                 .flatMap(i -> i)
                 .toList();
     }

--- a/csharp/src/main/java/com/ibm/plugin/rules/detection/dotnet/DotNetMLKem.java
+++ b/csharp/src/main/java/com/ibm/plugin/rules/detection/dotnet/DotNetMLKem.java
@@ -19,6 +19,7 @@
  */
 package com.ibm.plugin.rules.detection.dotnet;
 
+import com.ibm.engine.detection.MethodMatcher;
 import com.ibm.engine.language.csharp.tree.CSharpTree;
 import com.ibm.engine.model.context.KeyContext;
 import com.ibm.engine.model.factory.ValueActionFactory;
@@ -52,18 +53,17 @@ public final class DotNetMLKem {
                 .forObjectTypes(className)
                 .forMethods("GenerateKey")
                 .shouldBeDetectedAs(new ValueActionFactory<>(value))
-                .withoutParameters()
+                .withMethodParameter(MethodMatcher.ANY)
                 .buildForContext(new KeyContext(Map.of("kind", "MLKEM")))
                 .inBundle(() -> "DotNet")
                 .withoutDependingDetectionRules();
     }
 
-    private static final IDetectionRule<CSharpTree> MLKEM_512 = mlKemRule("MLKem512", "MLKEM512");
+    private static final IDetectionRule<CSharpTree> MLKEM_512 = mlKemRule("MLKem", "MLKEM512");
 
-    private static final IDetectionRule<CSharpTree> MLKEM_768 = mlKemRule("MLKem768", "MLKEM768");
+    private static final IDetectionRule<CSharpTree> MLKEM_768 = mlKemRule("MLKem", "MLKEM768");
 
-    private static final IDetectionRule<CSharpTree> MLKEM_1024 =
-            mlKemRule("MLKem1024", "MLKEM1024");
+    private static final IDetectionRule<CSharpTree> MLKEM_1024 = mlKemRule("MLKem", "MLKEM1024");
 
     @Nonnull
     public static List<IDetectionRule<CSharpTree>> rules() {

--- a/csharp/src/main/java/com/ibm/plugin/rules/detection/dotnet/DotNetMLKem.java
+++ b/csharp/src/main/java/com/ibm/plugin/rules/detection/dotnet/DotNetMLKem.java
@@ -1,0 +1,72 @@
+/*
+ * Sonar Cryptography Plugin
+ * Copyright (C) 2024 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.plugin.rules.detection.dotnet;
+
+import com.ibm.engine.language.csharp.tree.CSharpTree;
+import com.ibm.engine.model.context.KeyContext;
+import com.ibm.engine.model.factory.ValueActionFactory;
+import com.ibm.engine.rule.IDetectionRule;
+import com.ibm.engine.rule.builder.DetectionRuleBuilder;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nonnull;
+
+/**
+ * Detection rules for ML-KEM (FIPS 203) in .NET 9+.
+ *
+ * <p>Detects key generation for all three parameter sets:
+ *
+ * <ul>
+ *   <li>{@code MLKem512.GenerateKey()}
+ *   <li>{@code MLKem768.GenerateKey()}
+ *   <li>{@code MLKem1024.GenerateKey()}
+ * </ul>
+ */
+@SuppressWarnings("java:S1192")
+public final class DotNetMLKem {
+
+    private DotNetMLKem() {
+        // nothing
+    }
+
+    private static IDetectionRule<CSharpTree> mlKemRule(String className, String value) {
+        return new DetectionRuleBuilder<CSharpTree>()
+                .createDetectionRule()
+                .forObjectTypes(className)
+                .forMethods("GenerateKey")
+                .shouldBeDetectedAs(new ValueActionFactory<>(value))
+                .withoutParameters()
+                .buildForContext(new KeyContext(Map.of("kind", "MLKEM")))
+                .inBundle(() -> "DotNet")
+                .withoutDependingDetectionRules();
+    }
+
+    private static final IDetectionRule<CSharpTree> MLKEM_512 = mlKemRule("MLKem512", "MLKEM512");
+
+    private static final IDetectionRule<CSharpTree> MLKEM_768 = mlKemRule("MLKem768", "MLKEM768");
+
+    private static final IDetectionRule<CSharpTree> MLKEM_1024 =
+            mlKemRule("MLKem1024", "MLKEM1024");
+
+    @Nonnull
+    public static List<IDetectionRule<CSharpTree>> rules() {
+        return List.of(MLKEM_512, MLKEM_768, MLKEM_1024);
+    }
+}

--- a/csharp/src/main/java/com/ibm/plugin/translation/translator/contexts/CSharpKeyContextTranslator.java
+++ b/csharp/src/main/java/com/ibm/plugin/translation/translator/contexts/CSharpKeyContextTranslator.java
@@ -32,6 +32,7 @@ import com.ibm.mapper.model.KeyLength;
 import com.ibm.mapper.model.algorithms.DSA;
 import com.ibm.mapper.model.algorithms.ECDH;
 import com.ibm.mapper.model.algorithms.ECDSA;
+import com.ibm.mapper.model.algorithms.MLKEM;
 import com.ibm.mapper.model.algorithms.PBKDF2;
 import com.ibm.mapper.model.algorithms.RSA;
 import com.ibm.mapper.utils.DetectionLocation;
@@ -57,6 +58,7 @@ public final class CSharpKeyContextTranslator implements IContextTranslation<CSh
                 case "ECDH" -> Optional.of(new ECDH(detectionLocation));
                 case "DSA" -> Optional.of(new DSA(detectionLocation));
                 case "KDF" -> Optional.of(new PBKDF2(detectionLocation));
+                case "MLKEM" -> Optional.of(new MLKEM(detectionLocation));
                 default -> Optional.empty();
             };
         } else if (value instanceof KeySize<?> keySize) {

--- a/csharp/src/test/files/rules/detection/dotnet/DotNetMLKemTestFile.cs
+++ b/csharp/src/test/files/rules/detection/dotnet/DotNetMLKemTestFile.cs
@@ -1,0 +1,19 @@
+using System.Security.Cryptography;
+
+public class DotNetMLKemTest
+{
+    public void TestMLKem512()
+    {
+        var key = MLKem512.GenerateKey(); // Noncompliant
+    }
+
+    public void TestMLKem768()
+    {
+        var key = MLKem768.GenerateKey(); // Noncompliant
+    }
+
+    public void TestMLKem1024()
+    {
+        var key = MLKem1024.GenerateKey(); // Noncompliant
+    }
+}

--- a/csharp/src/test/files/rules/detection/dotnet/DotNetMLKemTestFile.cs
+++ b/csharp/src/test/files/rules/detection/dotnet/DotNetMLKemTestFile.cs
@@ -4,16 +4,16 @@ public class DotNetMLKemTest
 {
     public void TestMLKem512()
     {
-        var key = MLKem512.GenerateKey(); // Noncompliant
+        var key = MLKem.GenerateKey(MLKemAlgorithm.MLKem512); // Noncompliant
     }
 
     public void TestMLKem768()
     {
-        var key = MLKem768.GenerateKey(); // Noncompliant
+        var key = MLKem.GenerateKey(MLKemAlgorithm.MLKem768); // Noncompliant
     }
 
     public void TestMLKem1024()
     {
-        var key = MLKem1024.GenerateKey(); // Noncompliant
+        var key = MLKem.GenerateKey(MLKemAlgorithm.MLKem1024); // Noncompliant
     }
 }

--- a/csharp/src/test/java/com/ibm/plugin/rules/detection/dotnet/DotNetMLKemTest.java
+++ b/csharp/src/test/java/com/ibm/plugin/rules/detection/dotnet/DotNetMLKemTest.java
@@ -1,0 +1,72 @@
+/*
+ * Sonar Cryptography Plugin
+ * Copyright (C) 2024 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.plugin.rules.detection.dotnet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ibm.engine.detection.DetectionStore;
+import com.ibm.engine.language.csharp.CSharpCheck;
+import com.ibm.engine.language.csharp.CSharpScanContext;
+import com.ibm.engine.language.csharp.CSharpSymbol;
+import com.ibm.engine.language.csharp.tree.CSharpTree;
+import com.ibm.engine.model.IValue;
+import com.ibm.engine.model.ValueAction;
+import com.ibm.engine.model.context.KeyContext;
+import com.ibm.mapper.model.INode;
+import com.ibm.mapper.model.KeyEncapsulationMechanism;
+import com.ibm.plugin.CSharpVerifier;
+import com.ibm.plugin.TestBase;
+import java.util.List;
+import javax.annotation.Nonnull;
+import org.junit.jupiter.api.Test;
+
+class DotNetMLKemTest extends TestBase {
+
+    @Test
+    void test() throws Exception {
+        CSharpVerifier.verify("rules/detection/dotnet/DotNetMLKemTestFile.cs", this);
+    }
+
+    @Override
+    public void asserts(
+            int findingId,
+            @Nonnull
+                    DetectionStore<CSharpCheck, CSharpTree, CSharpSymbol, CSharpScanContext>
+                            detectionStore,
+            @Nonnull List<INode> nodes) {
+
+        /*
+         * Detection Store
+         */
+        assertThat(detectionStore.getDetectionValues()).hasSize(1);
+        assertThat(detectionStore.getDetectionValueContext()).isInstanceOf(KeyContext.class);
+        IValue<CSharpTree> value = detectionStore.getDetectionValues().get(0);
+        assertThat(value).isInstanceOf(ValueAction.class);
+        assertThat(value.asString()).isIn("MLKEM512", "MLKEM768", "MLKEM1024");
+
+        /*
+         * Translation
+         */
+        assertThat(nodes).hasSize(1);
+        INode node = nodes.get(0);
+        assertThat(node.getKind()).isEqualTo(KeyEncapsulationMechanism.class);
+        assertThat(node.asString()).startsWith("ML-KEM");
+    }
+}

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -56,6 +56,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <!-- This dependency enables IDE linting in Tink test files -->
+            <groupId>com.google.crypto.tink</groupId>
+            <artifactId>tink</artifactId>
+            <version>1.21.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>33.5.0-jre</version>

--- a/java/src/main/java/com/ibm/plugin/rules/detection/tink/TinkAead.java
+++ b/java/src/main/java/com/ibm/plugin/rules/detection/tink/TinkAead.java
@@ -1,0 +1,133 @@
+/*
+ * Sonar Cryptography Plugin
+ * Copyright (C) 2024 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.plugin.rules.detection.tink;
+
+import com.ibm.engine.detection.MethodMatcher;
+import com.ibm.engine.model.context.CipherContext;
+import com.ibm.engine.model.factory.ValueActionFactory;
+import com.ibm.engine.rule.IDetectionRule;
+import com.ibm.engine.rule.builder.DetectionRuleBuilder;
+import java.util.List;
+import javax.annotation.Nonnull;
+import org.sonar.plugins.java.api.tree.Tree;
+
+/**
+ * Detection rules for Google Tink AEAD.
+ *
+ * <p>Detects key generation and encrypt/decrypt operations:
+ *
+ * <ul>
+ *   <li>{@code KeysetHandle.generateNew(AeadKeyTemplates.AES128_GCM)}
+ *   <li>{@code KeysetHandle.generateNew(AeadKeyTemplates.AES256_GCM)}
+ *   <li>{@code KeysetHandle.generateNew(AeadKeyTemplates.AES128_CTR_HMAC_SHA256)}
+ *   <li>{@code KeysetHandle.generateNew(AeadKeyTemplates.AES256_CTR_HMAC_SHA256)}
+ *   <li>{@code aead.encrypt(plaintext, aad)}
+ *   <li>{@code aead.decrypt(ciphertext, aad)}
+ * </ul>
+ */
+@SuppressWarnings("java:S1192")
+public final class TinkAead {
+
+    private TinkAead() {
+        // nothing
+    }
+
+    // aead.encrypt(plaintext, aad)
+    private static final IDetectionRule<Tree> AEAD_ENCRYPT =
+            new DetectionRuleBuilder<Tree>()
+                    .createDetectionRule()
+                    .forObjectTypes("com.google.crypto.tink.Aead")
+                    .forMethods("encrypt")
+                    .shouldBeDetectedAs(new ValueActionFactory<>("ENCRYPT"))
+                    .withMethodParameter(MethodMatcher.ANY)
+                    .withMethodParameter(MethodMatcher.ANY)
+                    .buildForContext(new CipherContext())
+                    .inBundle(() -> "Tink")
+                    .withoutDependingDetectionRules();
+
+    // aead.decrypt(ciphertext, aad)
+    private static final IDetectionRule<Tree> AEAD_DECRYPT =
+            new DetectionRuleBuilder<Tree>()
+                    .createDetectionRule()
+                    .forObjectTypes("com.google.crypto.tink.Aead")
+                    .forMethods("decrypt")
+                    .shouldBeDetectedAs(new ValueActionFactory<>("DECRYPT"))
+                    .withMethodParameter(MethodMatcher.ANY)
+                    .withMethodParameter(MethodMatcher.ANY)
+                    .buildForContext(new CipherContext())
+                    .inBundle(() -> "Tink")
+                    .withoutDependingDetectionRules();
+
+    private static final List<IDetectionRule<Tree>> AEAD_OP_RULES =
+            List.of(AEAD_ENCRYPT, AEAD_DECRYPT);
+
+    // KeysetHandle.generateNew(AeadKeyTemplates.AES128_GCM)
+    private static final IDetectionRule<Tree> AES128_GCM =
+            new DetectionRuleBuilder<Tree>()
+                    .createDetectionRule()
+                    .forObjectTypes("com.google.crypto.tink.KeysetHandle")
+                    .forMethods("generateNew")
+                    .shouldBeDetectedAs(new ValueActionFactory<>("AES128_GCM"))
+                    .withAnyParameters()
+                    .buildForContext(new CipherContext())
+                    .inBundle(() -> "Tink")
+                    .withDependingDetectionRules(AEAD_OP_RULES);
+
+    // KeysetHandle.generateNew(AeadKeyTemplates.AES256_GCM)
+    private static final IDetectionRule<Tree> AES256_GCM =
+            new DetectionRuleBuilder<Tree>()
+                    .createDetectionRule()
+                    .forObjectTypes("com.google.crypto.tink.KeysetHandle")
+                    .forMethods("generateNew")
+                    .shouldBeDetectedAs(new ValueActionFactory<>("AES256_GCM"))
+                    .withAnyParameters()
+                    .buildForContext(new CipherContext())
+                    .inBundle(() -> "Tink")
+                    .withDependingDetectionRules(AEAD_OP_RULES);
+
+    // KeysetHandle.generateNew(AeadKeyTemplates.AES128_CTR_HMAC_SHA256)
+    private static final IDetectionRule<Tree> AES128_CTR_HMAC_SHA256 =
+            new DetectionRuleBuilder<Tree>()
+                    .createDetectionRule()
+                    .forObjectTypes("com.google.crypto.tink.KeysetHandle")
+                    .forMethods("generateNew")
+                    .shouldBeDetectedAs(new ValueActionFactory<>("AES128_CTR_HMAC_SHA256"))
+                    .withAnyParameters()
+                    .buildForContext(new CipherContext())
+                    .inBundle(() -> "Tink")
+                    .withDependingDetectionRules(AEAD_OP_RULES);
+
+    // KeysetHandle.generateNew(AeadKeyTemplates.AES256_CTR_HMAC_SHA256)
+    private static final IDetectionRule<Tree> AES256_CTR_HMAC_SHA256 =
+            new DetectionRuleBuilder<Tree>()
+                    .createDetectionRule()
+                    .forObjectTypes("com.google.crypto.tink.KeysetHandle")
+                    .forMethods("generateNew")
+                    .shouldBeDetectedAs(new ValueActionFactory<>("AES256_CTR_HMAC_SHA256"))
+                    .withAnyParameters()
+                    .buildForContext(new CipherContext())
+                    .inBundle(() -> "Tink")
+                    .withDependingDetectionRules(AEAD_OP_RULES);
+
+    @Nonnull
+    public static List<IDetectionRule<Tree>> rules() {
+        return List.of(AES128_GCM, AES256_GCM, AES128_CTR_HMAC_SHA256, AES256_CTR_HMAC_SHA256);
+    }
+}

--- a/java/src/main/java/com/ibm/plugin/rules/detection/tink/TinkDetectionRules.java
+++ b/java/src/main/java/com/ibm/plugin/rules/detection/tink/TinkDetectionRules.java
@@ -17,31 +17,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.ibm.plugin.rules.detection;
+package com.ibm.plugin.rules.detection.tink;
 
 import com.ibm.engine.rule.IDetectionRule;
-import com.ibm.plugin.rules.detection.bc.BouncyCastleDetectionRules;
-import com.ibm.plugin.rules.detection.jca.JcaDetectionRules;
-import com.ibm.plugin.rules.detection.ssl.SSLDetectionRules;
-import com.ibm.plugin.rules.detection.tink.TinkDetectionRules;
 import java.util.List;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import org.sonar.plugins.java.api.tree.Tree;
 
-public final class JavaDetectionRules {
-    private JavaDetectionRules() {
-        // private
+/** Aggregates all Google Tink detection rule lists. */
+public final class TinkDetectionRules {
+
+    private TinkDetectionRules() {
+        // nothing
     }
 
     @Nonnull
     public static List<IDetectionRule<Tree>> rules() {
-        return Stream.of(
-                        JcaDetectionRules.rules().stream(),
-                        BouncyCastleDetectionRules.rules().stream(),
-                        SSLDetectionRules.rules().stream(),
-                        TinkDetectionRules.rules().stream())
-                .flatMap(i -> i)
-                .toList();
+        return Stream.of(TinkAead.rules().stream()).flatMap(i -> i).toList();
     }
 }

--- a/java/src/main/java/com/ibm/plugin/translation/translator/contexts/JavaAbstractLibraryTranslator.java
+++ b/java/src/main/java/com/ibm/plugin/translation/translator/contexts/JavaAbstractLibraryTranslator.java
@@ -42,6 +42,7 @@ public abstract class JavaAbstractLibraryTranslator implements IContextTranslati
         return switch (bundleIdentifier.getIdentifier()) {
             case "Jca" -> translateJCA(value, detectionContext, detectionLocation);
             case "Bc" -> translateBC(value, detectionContext, detectionLocation);
+            case "Tink" -> translateTink(value, detectionContext, detectionLocation);
             default -> Optional.of(new Unknown(detectionLocation));
         };
     }
@@ -57,4 +58,12 @@ public abstract class JavaAbstractLibraryTranslator implements IContextTranslati
             @Nonnull IValue<Tree> value,
             @Nonnull IDetectionContext detectionContext,
             @Nonnull DetectionLocation detectionLocation);
+
+    @Nonnull
+    protected Optional<INode> translateTink(
+            @Nonnull IValue<Tree> value,
+            @Nonnull IDetectionContext detectionContext,
+            @Nonnull DetectionLocation detectionLocation) {
+        return Optional.empty();
+    }
 }

--- a/java/src/main/java/com/ibm/plugin/translation/translator/contexts/JavaCipherContextTranslator.java
+++ b/java/src/main/java/com/ibm/plugin/translation/translator/contexts/JavaCipherContextTranslator.java
@@ -202,4 +202,24 @@ public final class JavaCipherContextTranslator extends JavaAbstractLibraryTransl
         }
         return Optional.empty();
     }
+
+    @Nonnull
+    @Override
+    protected Optional<INode> translateTink(
+            @Nonnull IValue<Tree> value,
+            @Nonnull IDetectionContext detectionContext,
+            @Nonnull DetectionLocation detectionLocation) {
+        if (value instanceof ValueAction<?>) {
+            return switch (value.asString()) {
+                case "AES128_GCM", "AES256_GCM" ->
+                        Optional.of(
+                                new com.ibm.mapper.model.algorithms.AES(
+                                        AuthenticatedEncryption.class, detectionLocation));
+                case "AES128_CTR_HMAC_SHA256", "AES256_CTR_HMAC_SHA256" ->
+                        Optional.of(new com.ibm.mapper.model.algorithms.AES(detectionLocation));
+                default -> Optional.empty();
+            };
+        }
+        return Optional.empty();
+    }
 }

--- a/java/src/test/files/rules/detection/tink/TinkAeadTestFile.java
+++ b/java/src/test/files/rules/detection/tink/TinkAeadTestFile.java
@@ -1,0 +1,21 @@
+import com.google.crypto.tink.Aead;
+import com.google.crypto.tink.KeysetHandle;
+import com.google.crypto.tink.aead.AeadConfig;
+import com.google.crypto.tink.aead.AeadKeyTemplates;
+
+public class TinkAeadTestFile {
+
+    public void testAes128Gcm() throws Exception {
+        AeadConfig.register();
+        KeysetHandle keysetHandle =
+                KeysetHandle.generateNew(AeadKeyTemplates.AES128_GCM); // Noncompliant 4
+        Aead aead = keysetHandle.getPrimitive(Aead.class);
+    }
+
+    public void testAes256Gcm() throws Exception {
+        AeadConfig.register();
+        KeysetHandle keysetHandle =
+                KeysetHandle.generateNew(AeadKeyTemplates.AES256_GCM); // Noncompliant 4
+        Aead aead = keysetHandle.getPrimitive(Aead.class);
+    }
+}

--- a/java/src/test/java/com/ibm/plugin/rules/detection/tink/TinkAeadTest.java
+++ b/java/src/test/java/com/ibm/plugin/rules/detection/tink/TinkAeadTest.java
@@ -1,0 +1,79 @@
+/*
+ * Sonar Cryptography Plugin
+ * Copyright (C) 2024 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.plugin.rules.detection.tink;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ibm.engine.detection.DetectionStore;
+import com.ibm.engine.model.IValue;
+import com.ibm.engine.model.ValueAction;
+import com.ibm.engine.model.context.CipherContext;
+import com.ibm.mapper.model.AuthenticatedEncryption;
+import com.ibm.mapper.model.BlockCipher;
+import com.ibm.mapper.model.INode;
+import com.ibm.plugin.TestBase;
+import java.util.List;
+import javax.annotation.Nonnull;
+import org.junit.jupiter.api.Test;
+import org.sonar.java.checks.verifier.CheckVerifier;
+import org.sonar.plugins.java.api.JavaCheck;
+import org.sonar.plugins.java.api.JavaFileScannerContext;
+import org.sonar.plugins.java.api.semantic.Symbol;
+import org.sonar.plugins.java.api.tree.Tree;
+
+class TinkAeadTest extends TestBase {
+
+    @Test
+    void test() {
+        CheckVerifier.newVerifier()
+                .onFile("src/test/files/rules/detection/tink/TinkAeadTestFile.java")
+                .withChecks(this)
+                .withClassPath(
+                        com.google.common.collect.ImmutableList.of(
+                                new java.io.File(
+                                        System.getProperty("user.home")
+                                                + "/.m2/repository/com/google/crypto/tink/tink/1.21.0/tink-1.21.0.jar")))
+                .verifyIssues();
+    }
+
+    @Override
+    public void asserts(
+            int findingId,
+            @Nonnull DetectionStore<JavaCheck, Tree, Symbol, JavaFileScannerContext> detectionStore,
+            @Nonnull List<INode> nodes) {
+
+        /*
+         * Detection Store
+         */
+        assertThat(detectionStore.getDetectionValues()).hasSize(1);
+        assertThat(detectionStore.getDetectionValueContext()).isInstanceOf(CipherContext.class);
+        IValue<Tree> value = detectionStore.getDetectionValues().get(0);
+        assertThat(value).isInstanceOf(ValueAction.class);
+        assertThat(value.asString())
+                .isIn(
+                        "AES128_GCM", "AES256_GCM",
+                        "AES128_CTR_HMAC_SHA256", "AES256_CTR_HMAC_SHA256");
+
+        assertThat(nodes).hasSize(1);
+        INode node = nodes.get(0);
+        assertThat(node.getKind()).isIn(AuthenticatedEncryption.class, BlockCipher.class);
+        assertThat(node.asString()).isEqualTo("AES");
+    }
+}


### PR DESCRIPTION
## Summary
Adds detection rules for Google Tink's AEAD (Authenticated Encryption 
with Associated Data) primitive in Java. Tink is one of the most widely 
used Java cryptography libraries and currently has no detection coverage 
in this plugin.

## Changes
- `TinkAead.java`: detect `KeysetHandle.generateNew()` for four AEAD 
  key templates with `Aead.encrypt()` and `Aead.decrypt()` as depending rules
- `TinkDetectionRules.java`: aggregates all Tink detection rules
- `TinkAeadTestFile.java`: Java test file using real Tink 1.21.0 API
- `TinkAeadTest.java`: unit test verifying detection and translation
- `JavaDetectionRules.java`: registers TinkDetectionRules in rule aggregator
- `JavaAbstractLibraryTranslator.java`: adds `"Tink"` bundle dispatch
- `JavaCipherContextTranslator.java`: maps Tink AEAD templates to AES model nodes
- `java/pom.xml`: adds `com.google.crypto.tink:tink:1.21.0` as test dependency

## Key templates detected
- `AeadKeyTemplates.AES128_GCM`
- `AeadKeyTemplates.AES256_GCM`
- `AeadKeyTemplates.AES128_CTR_HMAC_SHA256`
- `AeadKeyTemplates.AES256_CTR_HMAC_SHA256`

## Testing
- 157 tests pass (was 156 before)
- mvn spotless:check passes
- mvn -B clean package -pl java passes
<img width="1126" height="446" alt="Screenshot 2026-05-08 041741" src="https://github.com/user-attachments/assets/324ff0c7-5b7c-4f0f-b829-686ee91cd98c" />

## Follow-up PR
- `Mac.computeMac()` / `Mac.verifyMac()` — HMAC detection
- `HybridEncrypt.encrypt()` / `HybridDecrypt.decrypt()` — hybrid encryption
- `PublicKeySign.sign()` / `PublicKeyVerify.verify()` — digital signatures
- `DeterministicAead` operations
- Additional key templates (ChaCha20Poly1305, AES-SIV, hybrid templates)