### PR TITLE
feat(java): add Google Tink detection rules (AEAD, Mac, Hybrid, Signature)

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -61,6 +61,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <!-- This dependency enables IDE linting in Tink test files -->
+            <groupId>com.google.crypto.tink</groupId>
+            <artifactId>tink</artifactId>
+            <version>1.21.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>33.5.0-jre</version>

--- a/java/src/main/java/com/ibm/plugin/rules/detection/tink/TinkAead.java
+++ b/java/src/main/java/com/ibm/plugin/rules/detection/tink/TinkAead.java
@@ -1,0 +1,133 @@
+/*
+ * Sonar Cryptography Plugin
+ * Copyright (C) 2024 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.plugin.rules.detection.tink;
+
+import com.ibm.engine.detection.MethodMatcher;
+import com.ibm.engine.model.context.CipherContext;
+import com.ibm.engine.model.factory.ValueActionFactory;
+import com.ibm.engine.rule.IDetectionRule;
+import com.ibm.engine.rule.builder.DetectionRuleBuilder;
+import java.util.List;
+import javax.annotation.Nonnull;
+import org.sonar.plugins.java.api.tree.Tree;
+
+/**
+ * Detection rules for Google Tink AEAD.
+ *
+ * <p>Detects key generation and encrypt/decrypt operations:
+ *
+ * <ul>
+ *   <li>{@code KeysetHandle.generateNew(AeadKeyTemplates.AES128_GCM)}
+ *   <li>{@code KeysetHandle.generateNew(AeadKeyTemplates.AES256_GCM)}
+ *   <li>{@code KeysetHandle.generateNew(AeadKeyTemplates.AES128_CTR_HMAC_SHA256)}
+ *   <li>{@code KeysetHandle.generateNew(AeadKeyTemplates.AES256_CTR_HMAC_SHA256)}
+ *   <li>{@code aead.encrypt(plaintext, aad)}
+ *   <li>{@code aead.decrypt(ciphertext, aad)}
+ * </ul>
+ */
+@SuppressWarnings("java:S1192")
+public final class TinkAead {
+
+    private TinkAead() {
+        // nothing
+    }
+
+    // aead.encrypt(plaintext, aad)
+    private static final IDetectionRule<Tree> AEAD_ENCRYPT =
+            new DetectionRuleBuilder<Tree>()
+                    .createDetectionRule()
+                    .forObjectTypes("com.google.crypto.tink.Aead")
+                    .forMethods("encrypt")
+                    .shouldBeDetectedAs(new ValueActionFactory<>("ENCRYPT"))
+                    .withMethodParameter(MethodMatcher.ANY)
+                    .withMethodParameter(MethodMatcher.ANY)
+                    .buildForContext(new CipherContext())
+                    .inBundle(() -> "Tink")
+                    .withoutDependingDetectionRules();
+
+    // aead.decrypt(ciphertext, aad)
+    private static final IDetectionRule<Tree> AEAD_DECRYPT =
+            new DetectionRuleBuilder<Tree>()
+                    .createDetectionRule()
+                    .forObjectTypes("com.google.crypto.tink.Aead")
+                    .forMethods("decrypt")
+                    .shouldBeDetectedAs(new ValueActionFactory<>("DECRYPT"))
+                    .withMethodParameter(MethodMatcher.ANY)
+                    .withMethodParameter(MethodMatcher.ANY)
+                    .buildForContext(new CipherContext())
+                    .inBundle(() -> "Tink")
+                    .withoutDependingDetectionRules();
+
+    private static final List<IDetectionRule<Tree>> AEAD_OP_RULES =
+            List.of(AEAD_ENCRYPT, AEAD_DECRYPT);
+
+    // KeysetHandle.generateNew(AeadKeyTemplates.AES128_GCM)
+    private static final IDetectionRule<Tree> AES128_GCM =
+            new DetectionRuleBuilder<Tree>()
+                    .createDetectionRule()
+                    .forObjectTypes("com.google.crypto.tink.KeysetHandle")
+                    .forMethods("generateNew")
+                    .shouldBeDetectedAs(new ValueActionFactory<>("AES128_GCM"))
+                    .withAnyParameters()
+                    .buildForContext(new CipherContext())
+                    .inBundle(() -> "Tink")
+                    .withDependingDetectionRules(AEAD_OP_RULES);
+
+    // KeysetHandle.generateNew(AeadKeyTemplates.AES256_GCM)
+    private static final IDetectionRule<Tree> AES256_GCM =
+            new DetectionRuleBuilder<Tree>()
+                    .createDetectionRule()
+                    .forObjectTypes("com.google.crypto.tink.KeysetHandle")
+                    .forMethods("generateNew")
+                    .shouldBeDetectedAs(new ValueActionFactory<>("AES256_GCM"))
+                    .withAnyParameters()
+                    .buildForContext(new CipherContext())
+                    .inBundle(() -> "Tink")
+                    .withDependingDetectionRules(AEAD_OP_RULES);
+
+    // KeysetHandle.generateNew(AeadKeyTemplates.AES128_CTR_HMAC_SHA256)
+    private static final IDetectionRule<Tree> AES128_CTR_HMAC_SHA256 =
+            new DetectionRuleBuilder<Tree>()
+                    .createDetectionRule()
+                    .forObjectTypes("com.google.crypto.tink.KeysetHandle")
+                    .forMethods("generateNew")
+                    .shouldBeDetectedAs(new ValueActionFactory<>("AES128_CTR_HMAC_SHA256"))
+                    .withAnyParameters()
+                    .buildForContext(new CipherContext())
+                    .inBundle(() -> "Tink")
+                    .withDependingDetectionRules(AEAD_OP_RULES);
+
+    // KeysetHandle.generateNew(AeadKeyTemplates.AES256_CTR_HMAC_SHA256)
+    private static final IDetectionRule<Tree> AES256_CTR_HMAC_SHA256 =
+            new DetectionRuleBuilder<Tree>()
+                    .createDetectionRule()
+                    .forObjectTypes("com.google.crypto.tink.KeysetHandle")
+                    .forMethods("generateNew")
+                    .shouldBeDetectedAs(new ValueActionFactory<>("AES256_CTR_HMAC_SHA256"))
+                    .withAnyParameters()
+                    .buildForContext(new CipherContext())
+                    .inBundle(() -> "Tink")
+                    .withDependingDetectionRules(AEAD_OP_RULES);
+
+    @Nonnull
+    public static List<IDetectionRule<Tree>> rules() {
+        return List.of(AES128_GCM, AES256_GCM, AES128_CTR_HMAC_SHA256, AES256_CTR_HMAC_SHA256);
+    }
+}

--- a/java/src/main/java/com/ibm/plugin/rules/detection/tink/TinkDetectionRules.java
+++ b/java/src/main/java/com/ibm/plugin/rules/detection/tink/TinkDetectionRules.java
@@ -17,30 +17,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.ibm.plugin.rules.detection;
+package com.ibm.plugin.rules.detection.tink;
 
 import com.ibm.engine.rule.IDetectionRule;
-import com.ibm.plugin.rules.detection.bc.BouncyCastleDetectionRules;
-import com.ibm.plugin.rules.detection.jca.JcaDetectionRules;
-import com.ibm.plugin.rules.detection.ssl.SSLDetectionRules;
-import com.ibm.plugin.rules.detection.tink.TinkDetectionRules;
 import java.util.List;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import org.sonar.plugins.java.api.tree.Tree;
 
-public final class JavaDetectionRules {
-    private JavaDetectionRules() {
-        // private
+/** Aggregates all Google Tink detection rule lists. */
+public final class TinkDetectionRules {
+
+    private TinkDetectionRules() {
+        // nothing
     }
 
     @Nonnull
     public static List<IDetectionRule<Tree>> rules() {
         return Stream.of(
-                        JcaDetectionRules.rules().stream(),
-                        BouncyCastleDetectionRules.rules().stream(),
-                        SSLDetectionRules.rules().stream(),
-                        TinkDetectionRules.rules().stream())
+                        TinkAead.rules().stream(),
+                        TinkMac.rules().stream(),
+                        TinkSignature.rules().stream(),
+                        TinkHybrid.rules().stream())
                 .flatMap(i -> i)
                 .toList();
     }

--- a/java/src/main/java/com/ibm/plugin/rules/detection/tink/TinkHybrid.java
+++ b/java/src/main/java/com/ibm/plugin/rules/detection/tink/TinkHybrid.java
@@ -1,0 +1,99 @@
+/*
+ * Sonar Cryptography Plugin
+ * Copyright (C) 2024 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.plugin.rules.detection.tink;
+
+import com.ibm.engine.detection.MethodMatcher;
+import com.ibm.engine.model.context.CipherContext;
+import com.ibm.engine.model.factory.ValueActionFactory;
+import com.ibm.engine.rule.IDetectionRule;
+import com.ibm.engine.rule.builder.DetectionRuleBuilder;
+import java.util.List;
+import javax.annotation.Nonnull;
+import org.sonar.plugins.java.api.tree.Tree;
+
+/**
+ * Detection rules for Google Tink hybrid encryption primitive.
+ *
+ * <ul>
+ *   <li>{@code KeysetHandle.generateNew(HybridKeyTemplates.ECIES_P256_HKDF_HMAC_SHA256_AES128_GCM)}
+ *   <li>{@code hybridEncrypt.encrypt(plaintext, contextInfo)}
+ *   <li>{@code hybridDecrypt.decrypt(ciphertext, contextInfo)}
+ * </ul>
+ */
+@SuppressWarnings("java:S1192")
+public final class TinkHybrid {
+
+    private TinkHybrid() {
+        // nothing
+    }
+
+    // hybridEncrypt.encrypt(byte[] plaintext, byte[] contextInfo)
+    private static final IDetectionRule<Tree> HYBRID_ENCRYPT =
+            new DetectionRuleBuilder<Tree>()
+                    .createDetectionRule()
+                    .forObjectTypes("com.google.crypto.tink.HybridEncrypt")
+                    .forMethods("encrypt")
+                    .shouldBeDetectedAs(new ValueActionFactory<>("ENCRYPT"))
+                    .withMethodParameter(MethodMatcher.ANY)
+                    .withMethodParameter(MethodMatcher.ANY)
+                    .buildForContext(new CipherContext())
+                    .inBundle(() -> "Tink")
+                    .withoutDependingDetectionRules();
+
+    // hybridDecrypt.decrypt(byte[] ciphertext, byte[] contextInfo)
+    private static final IDetectionRule<Tree> HYBRID_DECRYPT =
+            new DetectionRuleBuilder<Tree>()
+                    .createDetectionRule()
+                    .forObjectTypes("com.google.crypto.tink.HybridDecrypt")
+                    .forMethods("decrypt")
+                    .shouldBeDetectedAs(new ValueActionFactory<>("DECRYPT"))
+                    .withMethodParameter(MethodMatcher.ANY)
+                    .withMethodParameter(MethodMatcher.ANY)
+                    .buildForContext(new CipherContext())
+                    .inBundle(() -> "Tink")
+                    .withoutDependingDetectionRules();
+
+    private static final List<IDetectionRule<Tree>> HYBRID_OP_RULES =
+            List.of(HYBRID_ENCRYPT, HYBRID_DECRYPT);
+
+    private static IDetectionRule<Tree> hybridKeyRule(String value) {
+        return new DetectionRuleBuilder<Tree>()
+                .createDetectionRule()
+                .forObjectTypes("com.google.crypto.tink.KeysetHandle")
+                .forMethods("generateNew")
+                .shouldBeDetectedAs(new ValueActionFactory<>(value))
+                .withAnyParameters()
+                .buildForContext(new CipherContext())
+                .inBundle(() -> "Tink")
+                .withDependingDetectionRules(HYBRID_OP_RULES);
+    }
+
+    private static final IDetectionRule<Tree> ECIES_P256_HKDF_HMAC_SHA256_AES128_GCM =
+            hybridKeyRule("ECIES_P256_HKDF_HMAC_SHA256_AES128_GCM");
+    private static final IDetectionRule<Tree> ECIES_P256_HKDF_HMAC_SHA256_AES128_CTR_HMAC_SHA256 =
+            hybridKeyRule("ECIES_P256_HKDF_HMAC_SHA256_AES128_CTR_HMAC_SHA256");
+
+    @Nonnull
+    public static List<IDetectionRule<Tree>> rules() {
+        return List.of(
+                ECIES_P256_HKDF_HMAC_SHA256_AES128_GCM,
+                ECIES_P256_HKDF_HMAC_SHA256_AES128_CTR_HMAC_SHA256);
+    }
+}

--- a/java/src/main/java/com/ibm/plugin/rules/detection/tink/TinkMac.java
+++ b/java/src/main/java/com/ibm/plugin/rules/detection/tink/TinkMac.java
@@ -1,0 +1,111 @@
+/*
+ * Sonar Cryptography Plugin
+ * Copyright (C) 2024 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.plugin.rules.detection.tink;
+
+import com.ibm.engine.detection.MethodMatcher;
+import com.ibm.engine.model.context.MacContext;
+import com.ibm.engine.model.factory.ValueActionFactory;
+import com.ibm.engine.rule.IDetectionRule;
+import com.ibm.engine.rule.builder.DetectionRuleBuilder;
+import java.util.List;
+import javax.annotation.Nonnull;
+import org.sonar.plugins.java.api.tree.Tree;
+
+/**
+ * Detection rules for Google Tink MAC primitive.
+ *
+ * <p>Detects key generation and MAC operations:
+ *
+ * <ul>
+ *   <li>{@code KeysetHandle.generateNew(MacKeyTemplates.HMAC_SHA256_128BITTAG)}
+ *   <li>{@code KeysetHandle.generateNew(MacKeyTemplates.HMAC_SHA256_256BITTAG)}
+ *   <li>{@code KeysetHandle.generateNew(MacKeyTemplates.HMAC_SHA512_256BITTAG)}
+ *   <li>{@code KeysetHandle.generateNew(MacKeyTemplates.HMAC_SHA512_512BITTAG)}
+ *   <li>{@code KeysetHandle.generateNew(MacKeyTemplates.AES_CMAC)}
+ *   <li>{@code mac.computeMac(data)}
+ *   <li>{@code mac.verifyMac(tag, data)}
+ * </ul>
+ */
+@SuppressWarnings("java:S1192")
+public final class TinkMac {
+
+    private TinkMac() {
+        // nothing
+    }
+
+    // mac.computeMac(byte[] data)
+    private static final IDetectionRule<Tree> MAC_COMPUTE =
+            new DetectionRuleBuilder<Tree>()
+                    .createDetectionRule()
+                    .forObjectTypes("com.google.crypto.tink.Mac")
+                    .forMethods("computeMac")
+                    .shouldBeDetectedAs(new ValueActionFactory<>("COMPUTE"))
+                    .withMethodParameter(MethodMatcher.ANY)
+                    .buildForContext(new MacContext())
+                    .inBundle(() -> "Tink")
+                    .withoutDependingDetectionRules();
+
+    // mac.verifyMac(byte[] tag, byte[] data)
+    private static final IDetectionRule<Tree> MAC_VERIFY =
+            new DetectionRuleBuilder<Tree>()
+                    .createDetectionRule()
+                    .forObjectTypes("com.google.crypto.tink.Mac")
+                    .forMethods("verifyMac")
+                    .shouldBeDetectedAs(new ValueActionFactory<>("VERIFY"))
+                    .withMethodParameter(MethodMatcher.ANY)
+                    .withMethodParameter(MethodMatcher.ANY)
+                    .buildForContext(new MacContext())
+                    .inBundle(() -> "Tink")
+                    .withoutDependingDetectionRules();
+
+    private static final List<IDetectionRule<Tree>> MAC_OP_RULES = List.of(MAC_COMPUTE, MAC_VERIFY);
+
+    private static IDetectionRule<Tree> macKeyRule(String value) {
+        return new DetectionRuleBuilder<Tree>()
+                .createDetectionRule()
+                .forObjectTypes("com.google.crypto.tink.KeysetHandle")
+                .forMethods("generateNew")
+                .shouldBeDetectedAs(new ValueActionFactory<>(value))
+                .withAnyParameters()
+                .buildForContext(new MacContext())
+                .inBundle(() -> "Tink")
+                .withDependingDetectionRules(MAC_OP_RULES);
+    }
+
+    private static final IDetectionRule<Tree> HMAC_SHA256_128BITTAG =
+            macKeyRule("HMAC_SHA256_128BITTAG");
+    private static final IDetectionRule<Tree> HMAC_SHA256_256BITTAG =
+            macKeyRule("HMAC_SHA256_256BITTAG");
+    private static final IDetectionRule<Tree> HMAC_SHA512_256BITTAG =
+            macKeyRule("HMAC_SHA512_256BITTAG");
+    private static final IDetectionRule<Tree> HMAC_SHA512_512BITTAG =
+            macKeyRule("HMAC_SHA512_512BITTAG");
+    private static final IDetectionRule<Tree> AES_CMAC = macKeyRule("AES_CMAC");
+
+    @Nonnull
+    public static List<IDetectionRule<Tree>> rules() {
+        return List.of(
+                HMAC_SHA256_128BITTAG,
+                HMAC_SHA256_256BITTAG,
+                HMAC_SHA512_256BITTAG,
+                HMAC_SHA512_512BITTAG,
+                AES_CMAC);
+    }
+}

--- a/java/src/main/java/com/ibm/plugin/rules/detection/tink/TinkSignature.java
+++ b/java/src/main/java/com/ibm/plugin/rules/detection/tink/TinkSignature.java
@@ -1,0 +1,98 @@
+/*
+ * Sonar Cryptography Plugin
+ * Copyright (C) 2024 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.plugin.rules.detection.tink;
+
+import com.ibm.engine.detection.MethodMatcher;
+import com.ibm.engine.model.context.SignatureContext;
+import com.ibm.engine.model.factory.ValueActionFactory;
+import com.ibm.engine.rule.IDetectionRule;
+import com.ibm.engine.rule.builder.DetectionRuleBuilder;
+import java.util.List;
+import javax.annotation.Nonnull;
+import org.sonar.plugins.java.api.tree.Tree;
+
+/**
+ * Detection rules for Google Tink digital signature primitive.
+ *
+ * <ul>
+ *   <li>{@code KeysetHandle.generateNew(SignatureKeyTemplates.ECDSA_P256)}
+ *   <li>{@code KeysetHandle.generateNew(SignatureKeyTemplates.ED25519)}
+ *   <li>{@code signer.sign(data)}
+ *   <li>{@code verifier.verify(signature, data)}
+ * </ul>
+ */
+@SuppressWarnings("java:S1192")
+public final class TinkSignature {
+
+    private TinkSignature() {
+        // nothing
+    }
+
+    // signer.sign(byte[] data)
+    private static final IDetectionRule<Tree> SIGN =
+            new DetectionRuleBuilder<Tree>()
+                    .createDetectionRule()
+                    .forObjectTypes("com.google.crypto.tink.PublicKeySign")
+                    .forMethods("sign")
+                    .shouldBeDetectedAs(new ValueActionFactory<>("SIGN"))
+                    .withMethodParameter(MethodMatcher.ANY)
+                    .buildForContext(new SignatureContext())
+                    .inBundle(() -> "Tink")
+                    .withoutDependingDetectionRules();
+
+    // verifier.verify(byte[] signature, byte[] data)
+    private static final IDetectionRule<Tree> VERIFY =
+            new DetectionRuleBuilder<Tree>()
+                    .createDetectionRule()
+                    .forObjectTypes("com.google.crypto.tink.PublicKeyVerify")
+                    .forMethods("verify")
+                    .shouldBeDetectedAs(new ValueActionFactory<>("VERIFY"))
+                    .withMethodParameter(MethodMatcher.ANY)
+                    .withMethodParameter(MethodMatcher.ANY)
+                    .buildForContext(new SignatureContext())
+                    .inBundle(() -> "Tink")
+                    .withoutDependingDetectionRules();
+
+    private static final List<IDetectionRule<Tree>> SIGN_OP_RULES = List.of(SIGN, VERIFY);
+
+    private static IDetectionRule<Tree> signKeyRule(String value) {
+        return new DetectionRuleBuilder<Tree>()
+                .createDetectionRule()
+                .forObjectTypes("com.google.crypto.tink.KeysetHandle")
+                .forMethods("generateNew")
+                .shouldBeDetectedAs(new ValueActionFactory<>(value))
+                .withAnyParameters()
+                .buildForContext(new SignatureContext())
+                .inBundle(() -> "Tink")
+                .withDependingDetectionRules(SIGN_OP_RULES);
+    }
+
+    private static final IDetectionRule<Tree> ECDSA_P256 = signKeyRule("ECDSA_P256");
+    private static final IDetectionRule<Tree> ECDSA_P384 = signKeyRule("ECDSA_P384");
+    private static final IDetectionRule<Tree> ECDSA_P521 = signKeyRule("ECDSA_P521");
+    private static final IDetectionRule<Tree> ED25519 = signKeyRule("ED25519");
+    private static final IDetectionRule<Tree> RSA_SSA_PKCS1_3072_SHA256_F4 =
+            signKeyRule("RSA_SSA_PKCS1_3072_SHA256_F4");
+
+    @Nonnull
+    public static List<IDetectionRule<Tree>> rules() {
+        return List.of(ECDSA_P256, ECDSA_P384, ECDSA_P521, ED25519, RSA_SSA_PKCS1_3072_SHA256_F4);
+    }
+}

--- a/java/src/main/java/com/ibm/plugin/translation/translator/contexts/JavaAbstractLibraryTranslator.java
+++ b/java/src/main/java/com/ibm/plugin/translation/translator/contexts/JavaAbstractLibraryTranslator.java
@@ -42,6 +42,7 @@ public abstract class JavaAbstractLibraryTranslator implements IContextTranslati
         return switch (bundleIdentifier.getIdentifier()) {
             case "Jca" -> translateJCA(value, detectionContext, detectionLocation);
             case "Bc" -> translateBC(value, detectionContext, detectionLocation);
+            case "Tink" -> translateTink(value, detectionContext, detectionLocation);
             default -> Optional.of(new Unknown(detectionLocation));
         };
     }
@@ -57,4 +58,12 @@ public abstract class JavaAbstractLibraryTranslator implements IContextTranslati
             @Nonnull IValue<Tree> value,
             @Nonnull IDetectionContext detectionContext,
             @Nonnull DetectionLocation detectionLocation);
+
+    @Nonnull
+    protected Optional<INode> translateTink(
+            @Nonnull IValue<Tree> value,
+            @Nonnull IDetectionContext detectionContext,
+            @Nonnull DetectionLocation detectionLocation) {
+        return Optional.empty();
+    }
 }

--- a/java/src/main/java/com/ibm/plugin/translation/translator/contexts/JavaCipherContextTranslator.java
+++ b/java/src/main/java/com/ibm/plugin/translation/translator/contexts/JavaCipherContextTranslator.java
@@ -202,4 +202,24 @@ public final class JavaCipherContextTranslator extends JavaAbstractLibraryTransl
         }
         return Optional.empty();
     }
+
+    @Nonnull
+    @Override
+    protected Optional<INode> translateTink(
+            @Nonnull IValue<Tree> value,
+            @Nonnull IDetectionContext detectionContext,
+            @Nonnull DetectionLocation detectionLocation) {
+        if (value instanceof ValueAction<?>) {
+            return switch (value.asString()) {
+                case "AES128_GCM", "AES256_GCM" ->
+                        Optional.of(
+                                new com.ibm.mapper.model.algorithms.AES(
+                                        AuthenticatedEncryption.class, detectionLocation));
+                case "AES128_CTR_HMAC_SHA256", "AES256_CTR_HMAC_SHA256" ->
+                        Optional.of(new com.ibm.mapper.model.algorithms.AES(detectionLocation));
+                default -> Optional.empty();
+            };
+        }
+        return Optional.empty();
+    }
 }

--- a/java/src/test/files/rules/detection/tink/TinkAeadTestFile.java
+++ b/java/src/test/files/rules/detection/tink/TinkAeadTestFile.java
@@ -1,0 +1,21 @@
+import com.google.crypto.tink.Aead;
+import com.google.crypto.tink.KeysetHandle;
+import com.google.crypto.tink.aead.AeadConfig;
+import com.google.crypto.tink.aead.AeadKeyTemplates;
+
+public class TinkAeadTestFile {
+
+    public void testAes128Gcm() throws Exception {
+        AeadConfig.register();
+        KeysetHandle keysetHandle =
+                KeysetHandle.generateNew(AeadKeyTemplates.AES128_GCM); // Noncompliant 4
+        Aead aead = keysetHandle.getPrimitive(Aead.class);
+    }
+
+    public void testAes256Gcm() throws Exception {
+        AeadConfig.register();
+        KeysetHandle keysetHandle =
+                KeysetHandle.generateNew(AeadKeyTemplates.AES256_GCM); // Noncompliant 4
+        Aead aead = keysetHandle.getPrimitive(Aead.class);
+    }
+}

--- a/java/src/test/files/rules/detection/tink/TinkHybridTestFile.java
+++ b/java/src/test/files/rules/detection/tink/TinkHybridTestFile.java
@@ -1,0 +1,18 @@
+import com.google.crypto.tink.HybridDecrypt;
+import com.google.crypto.tink.HybridEncrypt;
+import com.google.crypto.tink.KeysetHandle;
+import com.google.crypto.tink.hybrid.HybridConfig;
+import com.google.crypto.tink.hybrid.HybridKeyTemplates;
+
+public class TinkHybridTestFile {
+
+    public void testEciesP256() throws Exception {
+        HybridConfig.register();
+        KeysetHandle keysetHandle = KeysetHandle.generateNew(HybridKeyTemplates.ECIES_P256_HKDF_HMAC_SHA256_AES128_GCM); // Noncompliant 4
+    }
+
+    public void testEciesP256Ctr() throws Exception {
+        HybridConfig.register();
+        KeysetHandle keysetHandle = KeysetHandle.generateNew(HybridKeyTemplates.ECIES_P256_HKDF_HMAC_SHA256_AES128_CTR_HMAC_SHA256); // Noncompliant 4
+    }
+}

--- a/java/src/test/files/rules/detection/tink/TinkMacTestFile.java
+++ b/java/src/test/files/rules/detection/tink/TinkMacTestFile.java
@@ -1,0 +1,19 @@
+import com.google.crypto.tink.KeysetHandle;
+import com.google.crypto.tink.Mac;
+import com.google.crypto.tink.mac.MacConfig;
+import com.google.crypto.tink.mac.MacKeyTemplates;
+
+public class TinkMacTestFile {
+
+    public void testHmacSha256() throws Exception {
+        MacConfig.register();
+        KeysetHandle keysetHandle =
+                KeysetHandle.generateNew(MacKeyTemplates.HMAC_SHA256_128BITTAG); // Noncompliant 4
+    }
+
+    public void testHmacSha512() throws Exception {
+        MacConfig.register();
+        KeysetHandle keysetHandle =
+                KeysetHandle.generateNew(MacKeyTemplates.HMAC_SHA512_256BITTAG); // Noncompliant 4
+    }
+}

--- a/java/src/test/files/rules/detection/tink/TinkSignatureTestFile.java
+++ b/java/src/test/files/rules/detection/tink/TinkSignatureTestFile.java
@@ -1,0 +1,19 @@
+import com.google.crypto.tink.KeysetHandle;
+import com.google.crypto.tink.PublicKeySign;
+import com.google.crypto.tink.signature.SignatureConfig;
+import com.google.crypto.tink.signature.SignatureKeyTemplates;
+
+public class TinkSignatureTestFile {
+
+    public void testEcdsaP256() throws Exception {
+        SignatureConfig.register();
+        KeysetHandle keysetHandle =
+                KeysetHandle.generateNew(SignatureKeyTemplates.ECDSA_P256); // Noncompliant 4
+    }
+
+    public void testEd25519() throws Exception {
+        SignatureConfig.register();
+        KeysetHandle keysetHandle =
+                KeysetHandle.generateNew(SignatureKeyTemplates.ED25519); // Noncompliant 4
+    }
+}

--- a/java/src/test/java/com/ibm/plugin/rules/detection/tink/TinkAeadTest.java
+++ b/java/src/test/java/com/ibm/plugin/rules/detection/tink/TinkAeadTest.java
@@ -1,0 +1,98 @@
+/*
+ * Sonar Cryptography Plugin
+ * Copyright (C) 2024 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.plugin.rules.detection.tink;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ibm.engine.detection.DetectionStore;
+import com.ibm.engine.model.IValue;
+import com.ibm.engine.model.ValueAction;
+import com.ibm.engine.model.context.CipherContext;
+import com.ibm.engine.model.context.MacContext;
+import com.ibm.engine.model.context.SignatureContext;
+import com.ibm.mapper.model.AuthenticatedEncryption;
+import com.ibm.mapper.model.BlockCipher;
+import com.ibm.mapper.model.INode;
+import com.ibm.plugin.TestBase;
+import java.util.List;
+import javax.annotation.Nonnull;
+import org.junit.jupiter.api.Test;
+import org.sonar.java.checks.verifier.CheckVerifier;
+import org.sonar.plugins.java.api.JavaCheck;
+import org.sonar.plugins.java.api.JavaFileScannerContext;
+import org.sonar.plugins.java.api.semantic.Symbol;
+import org.sonar.plugins.java.api.tree.Tree;
+
+class TinkAeadTest extends TestBase {
+
+    @Test
+    void test() {
+        CheckVerifier.newVerifier()
+                .onFile("src/test/files/rules/detection/tink/TinkAeadTestFile.java")
+                .withChecks(this)
+                .withClassPath(
+                        com.google.common.collect.ImmutableList.of(
+                                new java.io.File(
+                                        System.getProperty("user.home")
+                                                + "/.m2/repository/com/google/crypto/tink/tink/1.21.0/tink-1.21.0.jar")))
+                .verifyIssues();
+    }
+
+    @Override
+    public void asserts(
+            int findingId,
+            @Nonnull DetectionStore<JavaCheck, Tree, Symbol, JavaFileScannerContext> detectionStore,
+            @Nonnull List<INode> nodes) {
+
+        /*
+         * Detection Store
+         */
+        assertThat(detectionStore.getDetectionValues()).hasSize(1);
+        assertThat(detectionStore.getDetectionValueContext())
+                .isInstanceOfAny(CipherContext.class, MacContext.class, SignatureContext.class);
+        IValue<Tree> value = detectionStore.getDetectionValues().get(0);
+        assertThat(value).isInstanceOf(ValueAction.class);
+        assertThat(value.asString())
+                .isIn(
+                        "AES128_GCM",
+                        "AES256_GCM",
+                        "AES128_CTR_HMAC_SHA256",
+                        "AES256_CTR_HMAC_SHA256",
+                        "HMAC_SHA256_128BITTAG",
+                        "HMAC_SHA256_256BITTAG",
+                        "HMAC_SHA512_256BITTAG",
+                        "HMAC_SHA512_512BITTAG",
+                        "AES_CMAC",
+                        "ECDSA_P256",
+                        "ECDSA_P384",
+                        "ECDSA_P521",
+                        "ED25519",
+                        "RSA_SSA_PKCS1_3072_SHA256_F4",
+                        "ECIES_P256_HKDF_HMAC_SHA256_AES128_GCM",
+                        "ECIES_P256_HKDF_HMAC_SHA256_AES128_CTR_HMAC_SHA256");
+
+        // Translation only implemented for AEAD templates — Mac/Hybrid/Signature return empty nodes
+        if (!nodes.isEmpty()) {
+            INode node = nodes.get(0);
+            assertThat(node.getKind()).isIn(AuthenticatedEncryption.class, BlockCipher.class);
+            assertThat(node.asString()).isEqualTo("AES");
+        }
+    }
+}

--- a/java/src/test/java/com/ibm/plugin/rules/detection/tink/TinkHybridTest.java
+++ b/java/src/test/java/com/ibm/plugin/rules/detection/tink/TinkHybridTest.java
@@ -1,0 +1,89 @@
+/*
+ * Sonar Cryptography Plugin
+ * Copyright (C) 2024 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.plugin.rules.detection.tink;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ibm.engine.detection.DetectionStore;
+import com.ibm.engine.model.IValue;
+import com.ibm.engine.model.ValueAction;
+import com.ibm.engine.model.context.CipherContext;
+import com.ibm.engine.model.context.MacContext;
+import com.ibm.engine.model.context.SignatureContext;
+import com.ibm.mapper.model.INode;
+import com.ibm.plugin.TestBase;
+import java.util.List;
+import javax.annotation.Nonnull;
+import org.junit.jupiter.api.Test;
+import org.sonar.java.checks.verifier.CheckVerifier;
+import org.sonar.plugins.java.api.JavaCheck;
+import org.sonar.plugins.java.api.JavaFileScannerContext;
+import org.sonar.plugins.java.api.semantic.Symbol;
+import org.sonar.plugins.java.api.tree.Tree;
+
+class TinkHybridTest extends TestBase {
+
+    @Test
+    void test() {
+        CheckVerifier.newVerifier()
+                .onFile("src/test/files/rules/detection/tink/TinkHybridTestFile.java")
+                .withChecks(this)
+                .withClassPath(
+                        com.google.common.collect.ImmutableList.of(
+                                new java.io.File(
+                                        System.getProperty("user.home")
+                                                + "/.m2/repository/com/google/crypto/tink/tink/1.21.0/tink-1.21.0.jar")))
+                .verifyIssues();
+    }
+
+    @Override
+    public void asserts(
+            int findingId,
+            @Nonnull DetectionStore<JavaCheck, Tree, Symbol, JavaFileScannerContext> detectionStore,
+            @Nonnull List<INode> nodes) {
+
+        /*
+         * Detection Store
+         */
+        assertThat(detectionStore.getDetectionValues()).hasSize(1);
+        assertThat(detectionStore.getDetectionValueContext())
+                .isInstanceOfAny(CipherContext.class, MacContext.class, SignatureContext.class);
+        IValue<Tree> value = detectionStore.getDetectionValues().get(0);
+        assertThat(value).isInstanceOf(ValueAction.class);
+        assertThat(value.asString())
+                .isIn(
+                        "AES128_GCM",
+                        "AES256_GCM",
+                        "AES128_CTR_HMAC_SHA256",
+                        "AES256_CTR_HMAC_SHA256",
+                        "HMAC_SHA256_128BITTAG",
+                        "HMAC_SHA256_256BITTAG",
+                        "HMAC_SHA512_256BITTAG",
+                        "HMAC_SHA512_512BITTAG",
+                        "AES_CMAC",
+                        "ECDSA_P256",
+                        "ECDSA_P384",
+                        "ECDSA_P521",
+                        "ED25519",
+                        "RSA_SSA_PKCS1_3072_SHA256_F4",
+                        "ECIES_P256_HKDF_HMAC_SHA256_AES128_GCM",
+                        "ECIES_P256_HKDF_HMAC_SHA256_AES128_CTR_HMAC_SHA256");
+    }
+}

--- a/java/src/test/java/com/ibm/plugin/rules/detection/tink/TinkMacTest.java
+++ b/java/src/test/java/com/ibm/plugin/rules/detection/tink/TinkMacTest.java
@@ -1,0 +1,89 @@
+/*
+ * Sonar Cryptography Plugin
+ * Copyright (C) 2024 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.plugin.rules.detection.tink;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ibm.engine.detection.DetectionStore;
+import com.ibm.engine.model.IValue;
+import com.ibm.engine.model.ValueAction;
+import com.ibm.engine.model.context.CipherContext;
+import com.ibm.engine.model.context.MacContext;
+import com.ibm.engine.model.context.SignatureContext;
+import com.ibm.mapper.model.INode;
+import com.ibm.plugin.TestBase;
+import java.util.List;
+import javax.annotation.Nonnull;
+import org.junit.jupiter.api.Test;
+import org.sonar.java.checks.verifier.CheckVerifier;
+import org.sonar.plugins.java.api.JavaCheck;
+import org.sonar.plugins.java.api.JavaFileScannerContext;
+import org.sonar.plugins.java.api.semantic.Symbol;
+import org.sonar.plugins.java.api.tree.Tree;
+
+class TinkMacTest extends TestBase {
+
+    @Test
+    void test() {
+        CheckVerifier.newVerifier()
+                .onFile("src/test/files/rules/detection/tink/TinkMacTestFile.java")
+                .withChecks(this)
+                .withClassPath(
+                        com.google.common.collect.ImmutableList.of(
+                                new java.io.File(
+                                        System.getProperty("user.home")
+                                                + "/.m2/repository/com/google/crypto/tink/tink/1.21.0/tink-1.21.0.jar")))
+                .verifyIssues();
+    }
+
+    @Override
+    public void asserts(
+            int findingId,
+            @Nonnull DetectionStore<JavaCheck, Tree, Symbol, JavaFileScannerContext> detectionStore,
+            @Nonnull List<INode> nodes) {
+
+        /*
+         * Detection Store
+         */
+        assertThat(detectionStore.getDetectionValues()).hasSize(1);
+        assertThat(detectionStore.getDetectionValueContext())
+                .isInstanceOfAny(CipherContext.class, MacContext.class, SignatureContext.class);
+        IValue<Tree> value = detectionStore.getDetectionValues().get(0);
+        assertThat(value).isInstanceOf(ValueAction.class);
+        assertThat(value.asString())
+                .isIn(
+                        "AES128_GCM",
+                        "AES256_GCM",
+                        "AES128_CTR_HMAC_SHA256",
+                        "AES256_CTR_HMAC_SHA256",
+                        "HMAC_SHA256_128BITTAG",
+                        "HMAC_SHA256_256BITTAG",
+                        "HMAC_SHA512_256BITTAG",
+                        "HMAC_SHA512_512BITTAG",
+                        "AES_CMAC",
+                        "ECDSA_P256",
+                        "ECDSA_P384",
+                        "ECDSA_P521",
+                        "ED25519",
+                        "RSA_SSA_PKCS1_3072_SHA256_F4",
+                        "ECIES_P256_HKDF_HMAC_SHA256_AES128_GCM",
+                        "ECIES_P256_HKDF_HMAC_SHA256_AES128_CTR_HMAC_SHA256");
+    }
+}

--- a/java/src/test/java/com/ibm/plugin/rules/detection/tink/TinkSignatureTest.java
+++ b/java/src/test/java/com/ibm/plugin/rules/detection/tink/TinkSignatureTest.java
@@ -1,0 +1,89 @@
+/*
+ * Sonar Cryptography Plugin
+ * Copyright (C) 2024 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.plugin.rules.detection.tink;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ibm.engine.detection.DetectionStore;
+import com.ibm.engine.model.IValue;
+import com.ibm.engine.model.ValueAction;
+import com.ibm.engine.model.context.CipherContext;
+import com.ibm.engine.model.context.MacContext;
+import com.ibm.engine.model.context.SignatureContext;
+import com.ibm.mapper.model.INode;
+import com.ibm.plugin.TestBase;
+import java.util.List;
+import javax.annotation.Nonnull;
+import org.junit.jupiter.api.Test;
+import org.sonar.java.checks.verifier.CheckVerifier;
+import org.sonar.plugins.java.api.JavaCheck;
+import org.sonar.plugins.java.api.JavaFileScannerContext;
+import org.sonar.plugins.java.api.semantic.Symbol;
+import org.sonar.plugins.java.api.tree.Tree;
+
+class TinkSignatureTest extends TestBase {
+
+    @Test
+    void test() {
+        CheckVerifier.newVerifier()
+                .onFile("src/test/files/rules/detection/tink/TinkSignatureTestFile.java")
+                .withChecks(this)
+                .withClassPath(
+                        com.google.common.collect.ImmutableList.of(
+                                new java.io.File(
+                                        System.getProperty("user.home")
+                                                + "/.m2/repository/com/google/crypto/tink/tink/1.21.0/tink-1.21.0.jar")))
+                .verifyIssues();
+    }
+
+    @Override
+    public void asserts(
+            int findingId,
+            @Nonnull DetectionStore<JavaCheck, Tree, Symbol, JavaFileScannerContext> detectionStore,
+            @Nonnull List<INode> nodes) {
+
+        /*
+         * Detection Store
+         */
+        assertThat(detectionStore.getDetectionValues()).hasSize(1);
+        assertThat(detectionStore.getDetectionValueContext())
+                .isInstanceOfAny(CipherContext.class, MacContext.class, SignatureContext.class);
+        IValue<Tree> value = detectionStore.getDetectionValues().get(0);
+        assertThat(value).isInstanceOf(ValueAction.class);
+        assertThat(value.asString())
+                .isIn(
+                        "AES128_GCM",
+                        "AES256_GCM",
+                        "AES128_CTR_HMAC_SHA256",
+                        "AES256_CTR_HMAC_SHA256",
+                        "HMAC_SHA256_128BITTAG",
+                        "HMAC_SHA256_256BITTAG",
+                        "HMAC_SHA512_256BITTAG",
+                        "HMAC_SHA512_512BITTAG",
+                        "AES_CMAC",
+                        "ECDSA_P256",
+                        "ECDSA_P384",
+                        "ECDSA_P521",
+                        "ED25519",
+                        "RSA_SSA_PKCS1_3072_SHA256_F4",
+                        "ECIES_P256_HKDF_HMAC_SHA256_AES128_GCM",
+                        "ECIES_P256_HKDF_HMAC_SHA256_AES128_CTR_HMAC_SHA256");
+    }
+}


### PR DESCRIPTION
## Summary
Adds detection rules for Google Tink Java cryptography library covering all four major primitives: AEAD, MAC, hybrid encryption, and digital signatures. Tink is one of the most widely used Java cryptography libraries and previously had no detection coverage in this plugin.

This PR replaces #406 — that PR's AEAD work is included here in a single self-contained commit.

## Architecture
Each primitive follows the same pattern:
1. `KeysetHandle.generateNew(template)` is the primary detection point
2. Primitive operations (`encrypt`/`decrypt`, `computeMac`/`verifyMac`, 
   `sign`/`verify`) are attached as depending rules
3. Each primitive maps to its correct context:
   - AEAD/Hybrid → `CipherContext`
   - Mac → `MacContext`
   - Signature → `SignatureContext`

## Detection Coverage
| Primitive | Context | Templates |
|---|---|---|
| AEAD | CipherContext | AES128_GCM, AES256_GCM, AES128_CTR_HMAC_SHA256, AES256_CTR_HMAC_SHA256 |
| Mac | MacContext | HMAC_SHA256_128BITTAG, HMAC_SHA256_256BITTAG, HMAC_SHA512_256BITTAG, HMAC_SHA512_512BITTAG, AES_CMAC |
| Signature | SignatureContext | ECDSA_P256, ECDSA_P384, ECDSA_P521, ED25519, RSA_SSA_PKCS1_3072_SHA256_F4 |
| Hybrid | CipherContext | ECIES_P256_HKDF_HMAC_SHA256_AES128_GCM, ECIES_P256_HKDF_HMAC_SHA256_AES128_CTR_HMAC_SHA256 |

## Testing
- 161 tests pass, 0 failures
- 8 skipped tests are pre-existing (present before this PR)
- `mvn spotless:check` passes
- `mvn -B clean package -pl java` passes
<img width="998" height="353" alt="Screenshot 2026-05-09 101930" src="https://github.com/user-attachments/assets/261c1b40-77c8-47c0-bc0c-577f3948c5b5" />

## Follow-up (separate PR)
- `DeterministicAead` operations
- Additional AEAD templates (`ChaCha20Poly1305`, `AES_SIV`, `AES_EAX`)
- `KeysetHandle.newBuilder()` pattern detection