### PR TITLE
test(java): add BouncyCastle digest edge-case coverage

### DIFF
--- a/java/src/test/files/rules/detection/bc/signer/BcDigestEdgeCasesTestFile.java
+++ b/java/src/test/files/rules/detection/bc/signer/BcDigestEdgeCasesTestFile.java
@@ -1,0 +1,36 @@
+/*
+ * Sonar Cryptography Plugin
+ * Copyright (C) 2024 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.plugin.rules.detection.bc.signer;
+
+import org.bouncycastle.crypto.Digest;
+import org.bouncycastle.crypto.digests.WhirlpoolDigest;
+import org.bouncycastle.crypto.digests.TigerDigest;
+import org.bouncycastle.crypto.digests.RIPEMD160Digest;
+
+public class BcDigestEdgeCasesTestFile {
+
+    public static void test() {
+        Digest whirlpool = new WhirlpoolDigest(); // Noncompliant {{(MessageDigest) Whirlpool}}
+
+        Digest tiger = new TigerDigest(); // Noncompliant {{(MessageDigest) Tiger}}
+
+        Digest ripemd = new RIPEMD160Digest(); // Noncompliant {{(MessageDigest) RIPEMD-160}}
+    }
+}

--- a/java/src/test/java/com/ibm/plugin/rules/detection/bc/signer/BcDigestEdgeCasesTest.java
+++ b/java/src/test/java/com/ibm/plugin/rules/detection/bc/signer/BcDigestEdgeCasesTest.java
@@ -20,6 +20,7 @@
 package com.ibm.plugin.rules.detection.bc.signer;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.ibm.engine.detection.DetectionStore;
 import com.ibm.engine.model.IValue;
@@ -181,6 +182,8 @@ class BcDigestEdgeCasesTest extends TestBase {
             assertThat(digestSizeNode).isNotNull();
             assertThat(digestSizeNode.getChildren()).isEmpty();
             assertThat(digestSizeNode.asString()).isEqualTo("160");
+        } else {
+            fail("Unexpected findingId: " + findingId);
         }
     }
 }

--- a/java/src/test/java/com/ibm/plugin/rules/detection/bc/signer/BcDigestEdgeCasesTest.java
+++ b/java/src/test/java/com/ibm/plugin/rules/detection/bc/signer/BcDigestEdgeCasesTest.java
@@ -1,0 +1,186 @@
+/*
+ * Sonar Cryptography Plugin
+ * Copyright (C) 2024 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.plugin.rules.detection.bc.signer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ibm.engine.detection.DetectionStore;
+import com.ibm.engine.model.IValue;
+import com.ibm.engine.model.ValueAction;
+import com.ibm.engine.model.context.DigestContext;
+import com.ibm.mapper.model.BlockSize;
+import com.ibm.mapper.model.DigestSize;
+import com.ibm.mapper.model.INode;
+import com.ibm.mapper.model.MessageDigest;
+import com.ibm.mapper.model.NumberOfIterations;
+import com.ibm.mapper.model.functionality.Digest;
+import com.ibm.plugin.TestBase;
+import com.ibm.plugin.rules.detection.bc.BouncyCastleJars;
+import java.util.List;
+import javax.annotation.Nonnull;
+import org.junit.jupiter.api.Test;
+import org.sonar.java.checks.verifier.CheckVerifier;
+import org.sonar.plugins.java.api.JavaCheck;
+import org.sonar.plugins.java.api.JavaFileScannerContext;
+import org.sonar.plugins.java.api.semantic.Symbol;
+import org.sonar.plugins.java.api.tree.Tree;
+
+class BcDigestEdgeCasesTest extends TestBase {
+    @Test
+    void test() {
+        CheckVerifier.newVerifier()
+                .onFile(
+                        "src/test/files/rules/detection/bc/signer/BcDigestEdgeCasesTestFile.java")
+                .withChecks(this)
+                .withClassPath(BouncyCastleJars.latestJar)
+                .verifyIssues();
+    }
+
+    @Override
+    public void asserts(
+            int findingId,
+            @Nonnull DetectionStore<JavaCheck, Tree, Symbol, JavaFileScannerContext> detectionStore,
+            @Nonnull List<INode> nodes) {
+        if (findingId == 0) {
+            /*
+             * Detection Store
+             */
+            assertThat(detectionStore).isNotNull();
+            assertThat(detectionStore.getDetectionValues()).hasSize(1);
+            assertThat(detectionStore.getDetectionValueContext()).isInstanceOf(DigestContext.class);
+            IValue<Tree> value0 = detectionStore.getDetectionValues().get(0);
+            assertThat(value0).isInstanceOf(ValueAction.class);
+            assertThat(value0.asString()).isEqualTo("WhirlpoolDigest");
+
+            /*
+             * Translation
+             */
+            assertThat(nodes).hasSize(1);
+
+            // MessageDigest
+            INode messageDigestNode = nodes.get(0);
+            assertThat(messageDigestNode.getKind()).isEqualTo(MessageDigest.class);
+            assertThat(messageDigestNode.getChildren()).hasSize(4);
+            assertThat(messageDigestNode.asString()).isEqualTo("Whirlpool");
+
+            // Digest under MessageDigest
+            INode digestNode = messageDigestNode.getChildren().get(Digest.class);
+            assertThat(digestNode).isNotNull();
+            assertThat(digestNode.getChildren()).isEmpty();
+            assertThat(digestNode.asString()).isEqualTo("DIGEST");
+
+            // BlockSize under MessageDigest
+            INode blockSizeNode = messageDigestNode.getChildren().get(BlockSize.class);
+            assertThat(blockSizeNode).isNotNull();
+            assertThat(blockSizeNode.getChildren()).isEmpty();
+            assertThat(blockSizeNode.asString()).isEqualTo("512");
+
+            // DigestSize under MessageDigest
+            INode digestSizeNode = messageDigestNode.getChildren().get(DigestSize.class);
+            assertThat(digestSizeNode).isNotNull();
+            assertThat(digestSizeNode.getChildren()).isEmpty();
+            assertThat(digestSizeNode.asString()).isEqualTo("512");
+
+            // NumberOfIterations under MessageDigest
+            INode iterationsNode = messageDigestNode.getChildren().get(NumberOfIterations.class);
+            assertThat(iterationsNode).isNotNull();
+            assertThat(iterationsNode.getChildren()).isEmpty();
+            assertThat(iterationsNode.asString()).isEqualTo("10");
+        } else if (findingId == 1) {
+            /*
+             * Detection Store
+             */
+            assertThat(detectionStore).isNotNull();
+            assertThat(detectionStore.getDetectionValues()).hasSize(1);
+            assertThat(detectionStore.getDetectionValueContext()).isInstanceOf(DigestContext.class);
+            IValue<Tree> value0 = detectionStore.getDetectionValues().get(0);
+            assertThat(value0).isInstanceOf(ValueAction.class);
+            assertThat(value0.asString()).isEqualTo("TigerDigest");
+
+            /*
+             * Translation
+             */
+            assertThat(nodes).hasSize(1);
+
+            // MessageDigest
+            INode messageDigestNode = nodes.get(0);
+            assertThat(messageDigestNode.getKind()).isEqualTo(MessageDigest.class);
+            assertThat(messageDigestNode.getChildren()).hasSize(4);
+            assertThat(messageDigestNode.asString()).isEqualTo("Tiger");
+
+            // Digest under MessageDigest
+            INode digestNode = messageDigestNode.getChildren().get(Digest.class);
+            assertThat(digestNode).isNotNull();
+            assertThat(digestNode.getChildren()).isEmpty();
+            assertThat(digestNode.asString()).isEqualTo("DIGEST");
+
+            // BlockSize under MessageDigest
+            INode blockSizeNode = messageDigestNode.getChildren().get(BlockSize.class);
+            assertThat(blockSizeNode).isNotNull();
+            assertThat(blockSizeNode.getChildren()).isEmpty();
+            assertThat(blockSizeNode.asString()).isEqualTo("512");
+
+            // DigestSize under MessageDigest
+            INode digestSizeNode = messageDigestNode.getChildren().get(DigestSize.class);
+            assertThat(digestSizeNode).isNotNull();
+            assertThat(digestSizeNode.getChildren()).isEmpty();
+            assertThat(digestSizeNode.asString()).isEqualTo("192");
+
+            // NumberOfIterations under MessageDigest
+            INode iterationsNode = messageDigestNode.getChildren().get(NumberOfIterations.class);
+            assertThat(iterationsNode).isNotNull();
+            assertThat(iterationsNode.getChildren()).isEmpty();
+            assertThat(iterationsNode.asString()).isEqualTo("24");
+        } else if (findingId == 2) {
+            /*
+             * Detection Store
+             */
+            assertThat(detectionStore).isNotNull();
+            assertThat(detectionStore.getDetectionValues()).hasSize(1);
+            assertThat(detectionStore.getDetectionValueContext()).isInstanceOf(DigestContext.class);
+            IValue<Tree> value0 = detectionStore.getDetectionValues().get(0);
+            assertThat(value0).isInstanceOf(ValueAction.class);
+            assertThat(value0.asString()).isEqualTo("RIPEMD160Digest");
+
+            /*
+             * Translation
+             */
+            assertThat(nodes).hasSize(1);
+
+            // MessageDigest
+            INode messageDigestNode = nodes.get(0);
+            assertThat(messageDigestNode.getKind()).isEqualTo(MessageDigest.class);
+            assertThat(messageDigestNode.getChildren()).hasSize(2);
+            assertThat(messageDigestNode.asString()).isEqualTo("RIPEMD-160");
+
+            // Digest under MessageDigest
+            INode digestNode = messageDigestNode.getChildren().get(Digest.class);
+            assertThat(digestNode).isNotNull();
+            assertThat(digestNode.getChildren()).isEmpty();
+            assertThat(digestNode.asString()).isEqualTo("DIGEST");
+
+            // DigestSize under MessageDigest
+            INode digestSizeNode = messageDigestNode.getChildren().get(DigestSize.class);
+            assertThat(digestSizeNode).isNotNull();
+            assertThat(digestSizeNode.getChildren()).isEmpty();
+            assertThat(digestSizeNode.asString()).isEqualTo("160");
+        }
+    }
+}


### PR DESCRIPTION
This PR adds explicit regression coverage for additional BouncyCastle digest implementations that were already registered through `BcDigests` but did not have dedicated tests.

### Added coverage

* `WhirlpoolDigest`
* `TigerDigest`
* `RIPEMD160Digest`

### What changed

* Added `BcDigestEdgeCasesTestFile` with digest instantiations and detection assertions
* Added `BcDigestEdgeCasesTest`
* Verified detection and translation metadata for:

  * digest functionality
  * digest size
  * block size (where applicable)
  * iteration information (where applicable)

### Validation

```bash
mvn -pl java -Dtest=BcDigestEdgeCasesTest test
mvn test -pl java
```

### Notes

The digest implementations were already registered in `BcDigests`, but explicit edge-case coverage for these variants was missing. This PR focuses only on regression coverage and does not modify existing translation behavior.

Related: #31
