### PR TITLE
Ed25519 and Ed448 generate() rules were matching too broadly

### DIFF
--- a/python/src/main/java/com/ibm/plugin/rules/detection/asymmetric/PycaSign.java
+++ b/python/src/main/java/com/ibm/plugin/rules/detection/asymmetric/PycaSign.java
@@ -43,7 +43,7 @@ public final class PycaSign {
                             "cryptography.hazmat.primitives.asymmetric.ed25519.Ed25519PrivateKey")
                     .forMethods("generate")
                     .shouldBeDetectedAs(new KeyActionFactory<>(KeyAction.Action.GENERATION))
-                    .withAnyParameters()
+                    .withoutParameters()
                     .buildForContext(new PrivateKeyContext(Map.of("algorithm", "Ed25519")))
                     .inBundle(() -> "Pyca")
                     .withoutDependingDetectionRules();
@@ -55,7 +55,7 @@ public final class PycaSign {
                             "cryptography.hazmat.primitives.asymmetric.ed448.Ed448PrivateKey")
                     .forMethods("generate")
                     .shouldBeDetectedAs(new KeyActionFactory<>(KeyAction.Action.GENERATION))
-                    .withAnyParameters()
+                    .withoutParameters()
                     .buildForContext(new PrivateKeyContext(Map.of("algorithm", "Ed448")))
                     .inBundle(() -> "Pyca")
                     .withoutDependingDetectionRules();


### PR DESCRIPTION
Fixes #300

The generate() rules for Ed25519 and Ed448 were using withAnyParameters(), 
which caused the scanner to match any .generate() call regardless of parameters.

The actual Ed25519PrivateKey.generate() and Ed448PrivateKey.generate() from 
pyca/cryptography take no parameters. So withoutParameters() is the correct matcher.

Reproducer from the issue — this was getting flagged as Edwards448 Key Pair Generation:

    generated_ids = self.vlm_model.generate(
        **inputs,
        max_new_tokens=self.max_new_tokens,
    )

Changed withAnyParameters() to withoutParameters() in both SIGN_ED25519 
and SIGN_ED448 rules in PycaSign.java.