### PR TITLE
Fix algorithm recast child map copy

### DIFF
--- a/enricher/src/test/java/com/ibm/enricher/algorithm/AESEnricherTest.java
+++ b/enricher/src/test/java/com/ibm/enricher/algorithm/AESEnricherTest.java
@@ -80,6 +80,25 @@ class AESEnricherTest extends TestBase {
     }
 
     @Test
+    void recastAesDoesNotShareChildrenWithOriginal() {
+        DetectionLocation testDetectionLocation =
+                new DetectionLocation("testfile", 1, 1, List.of("test"), () -> "SSL");
+        final AES aes = new AES(128, new GCM(testDetectionLocation), testDetectionLocation);
+
+        final AESEnricher aesEnricher = new AESEnricher();
+        final INode enriched = aesEnricher.enrich(aes);
+
+        assertThat(enriched).isInstanceOf(AES.class);
+        final AES enrichedAES = (AES) enriched;
+        enrichedAES.removeChildOfType(Oid.class);
+
+        assertThat(enrichedAES.hasChildOfType(Oid.class)).isEmpty();
+        assertThat(aes.hasChildOfType(Oid.class)).isPresent();
+        assertThat(aes.hasChildOfType(Oid.class).get().asString())
+                .isEqualTo("2.16.840.1.101.3.4.1.6");
+    }
+
+    @Test
     void defaultKeyLengthForJca() {
         DetectionLocation testDetectionLocation =
                 new DetectionLocation("testfile", 1, 1, List.of("test"), () -> "Jca");

--- a/mapper/src/main/java/com/ibm/mapper/model/Algorithm.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/Algorithm.java
@@ -36,7 +36,7 @@ public class Algorithm implements IAlgorithm {
     public Algorithm(
             @Nonnull IAlgorithm algorithm, @Nonnull final Class<? extends IPrimitive> asKind) {
         this.name = algorithm.getName();
-        this.children = algorithm.getChildren();
+        this.children = new HashMap<>(algorithm.getChildren());
         this.detectionLocation = algorithm.getDetectionContext();
         this.kind = asKind;
         this.origin = algorithm.getOrigin();

--- a/mapper/src/main/java/com/ibm/mapper/model/Key.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/Key.java
@@ -45,7 +45,7 @@ public class Key implements IAsset {
             @Nonnull DetectionLocation detectionLocation,
             @Nonnull final Class<? extends Key> asKind) {
         this.name = key.name;
-        this.children = key.getChildren();
+        this.children = new HashMap<>(key.getChildren());
         this.detectionLocation = detectionLocation;
         this.kind = asKind;
     }

--- a/mapper/src/main/java/com/ibm/mapper/model/Protocol.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/Protocol.java
@@ -33,7 +33,7 @@ public class Protocol implements IAsset {
 
     public Protocol(@Nonnull Protocol protocol, @Nonnull final Class<? extends Protocol> asKind) {
         this.type = protocol.type;
-        this.children = protocol.getChildren();
+        this.children = new HashMap<>(protocol.getChildren());
         this.detectionLocation = protocol.detectionLocation;
         this.kind = asKind;
     }

--- a/mapper/src/test/java/com/ibm/mapper/model/AlgorithmTest.java
+++ b/mapper/src/test/java/com/ibm/mapper/model/AlgorithmTest.java
@@ -1,0 +1,54 @@
+/*
+ * Sonar Cryptography Plugin
+ * Copyright (C) 2024 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.mapper.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ibm.mapper.utils.DetectionLocation;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class AlgorithmTest {
+
+    @Test
+    void recastConstructor_shouldCopyChildrenMap() {
+        DetectionLocation detectionLocation =
+                new DetectionLocation("testfile", 1, 1, List.of("test"), () -> "SSL");
+
+        // Create an original algorithm with a child
+        Algorithm original = new Algorithm("AES", BlockCipher.class, detectionLocation);
+        Algorithm child = new Algorithm("GCM", BlockCipher.class, detectionLocation);
+        original.put(child);
+
+        // Recast the algorithm
+        Algorithm recast = new Algorithm(original, AuthenticatedEncryption.class);
+
+        // The children maps must not be the same instance
+        assertThat(recast.getChildren()).isNotSameAs(original.getChildren());
+
+        // The children maps must have equal content
+        assertThat(recast.getChildren()).isEqualTo(original.getChildren());
+
+        // Mutating the recast's children must not affect the original
+        recast.getChildren().clear();
+        assertThat(original.getChildren()).isNotEmpty();
+        assertThat(original.hasChildOfType(BlockCipher.class)).isPresent();
+    }
+}

--- a/mapper/src/test/java/com/ibm/mapper/model/KeyTest.java
+++ b/mapper/src/test/java/com/ibm/mapper/model/KeyTest.java
@@ -1,0 +1,67 @@
+/*
+ * Sonar Cryptography Plugin
+ * Copyright (C) 2024 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.mapper.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ibm.mapper.utils.DetectionLocation;
+import java.util.List;
+import javax.annotation.Nonnull;
+import org.junit.jupiter.api.Test;
+
+class KeyTest {
+
+    /**
+     * A small test-only subclass to exercise the protected recast constructor {@link Key#Key(Key,
+     * DetectionLocation, Class)}.
+     */
+    private static final class TestKey extends Key {
+        TestKey(@Nonnull Key key, @Nonnull DetectionLocation detectionLocation) {
+            super(key, detectionLocation, TestKey.class);
+        }
+    }
+
+    @Test
+    void recastConstructor_shouldCopyChildrenMap() {
+        DetectionLocation detectionLocation =
+                new DetectionLocation("testfile", 1, 1, List.of("test"), () -> "SSL");
+
+        // Create an original key with a child via its IAlgorithm constructor
+        Algorithm algorithm = new Algorithm("AES", BlockCipher.class, detectionLocation);
+        Key original = new Key(algorithm);
+
+        // Verify the original has children
+        assertThat(original.getChildren()).isNotEmpty();
+
+        // Recast the key using the protected constructor
+        TestKey recast = new TestKey(original, detectionLocation);
+
+        // The children maps must not be the same instance
+        assertThat(recast.getChildren()).isNotSameAs(original.getChildren());
+
+        // The children maps must have equal content
+        assertThat(recast.getChildren()).isEqualTo(original.getChildren());
+
+        // Mutating the recast's children must not affect the original
+        recast.getChildren().clear();
+        assertThat(original.getChildren()).isNotEmpty();
+        assertThat(original.hasChildOfType(BlockCipher.class)).isPresent();
+    }
+}

--- a/mapper/src/test/java/com/ibm/mapper/model/ProtocolTest.java
+++ b/mapper/src/test/java/com/ibm/mapper/model/ProtocolTest.java
@@ -1,0 +1,62 @@
+/*
+ * Sonar Cryptography Plugin
+ * Copyright (C) 2024 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.mapper.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ibm.mapper.utils.DetectionLocation;
+import java.util.List;
+import javax.annotation.Nonnull;
+import org.junit.jupiter.api.Test;
+
+class ProtocolTest {
+
+    /** A simple Protocol subclass to exercise the recast constructor. */
+    private static final class TestProtocol extends Protocol {
+        TestProtocol(@Nonnull Protocol protocol) {
+            super(protocol, TestProtocol.class);
+        }
+    }
+
+    @Test
+    void recastConstructor_shouldCopyChildrenMap() {
+        DetectionLocation detectionLocation =
+                new DetectionLocation("testfile", 1, 1, List.of("test"), () -> "SSL");
+
+        // Create an original protocol with a child
+        Protocol original = new Protocol("TLS", detectionLocation);
+        Algorithm child = new Algorithm("AES", BlockCipher.class, detectionLocation);
+        original.put(child);
+
+        // Recast the protocol
+        TestProtocol recast = new TestProtocol(original);
+
+        // The children maps must not be the same instance
+        assertThat(recast.getChildren()).isNotSameAs(original.getChildren());
+
+        // The children maps must have equal content
+        assertThat(recast.getChildren()).isEqualTo(original.getChildren());
+
+        // Mutating the recast's children must not affect the original
+        recast.getChildren().clear();
+        assertThat(original.getChildren()).isNotEmpty();
+        assertThat(original.hasChildOfType(BlockCipher.class)).isPresent();
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #451

This fixes a shallow-copy bug in the `Algorithm(IAlgorithm, asKind)` recast constructor.

The constructor previously reused the source algorithm's mutable children map, which meant the original algorithm node and the recast algorithm node shared the same child state.

## Root Cause

The recast constructor assigned the original map reference directly:

```java
this.children = algorithm.getChildren();
```

Because of this, mutating children on the recast node could also mutate the original algorithm node.

## Changes

- Copy the children map in `Algorithm(IAlgorithm, asKind)` using `new HashMap<>(algorithm.getChildren())`
- Add an AES-GCM regression test covering the recast path through `AESEnricher`
- Verify that mutating the returned/recast AES node does not remove children from the original AES node

## Validation

Ran the targeted regression test:

```bash
mvn -pl enricher -am -Dtest=AESEnricherTest -Dsurefire.failIfNoSpecifiedTests=false -Dexec.skip=true test
```

Result:

```text
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```