### PR TITLE
Fix Algorithm deepCopy subtype preservation

### DIFF
--- a/enricher/src/test/java/com/ibm/enricher/algorithm/AESEnricherTest.java
+++ b/enricher/src/test/java/com/ibm/enricher/algorithm/AESEnricherTest.java
@@ -80,6 +80,25 @@ class AESEnricherTest extends TestBase {
     }
 
     @Test
+    void recastAesDoesNotShareChildrenWithOriginal() {
+        DetectionLocation testDetectionLocation =
+                new DetectionLocation("testfile", 1, 1, List.of("test"), () -> "SSL");
+        final AES aes = new AES(128, new GCM(testDetectionLocation), testDetectionLocation);
+
+        final AESEnricher aesEnricher = new AESEnricher();
+        final INode enriched = aesEnricher.enrich(aes);
+
+        assertThat(enriched).isInstanceOf(AES.class);
+        final AES enrichedAES = (AES) enriched;
+        enrichedAES.removeChildOfType(Oid.class);
+
+        assertThat(enrichedAES.hasChildOfType(Oid.class)).isEmpty();
+        assertThat(aes.hasChildOfType(Oid.class)).isPresent();
+        assertThat(aes.hasChildOfType(Oid.class).get().asString())
+                .isEqualTo("2.16.840.1.101.3.4.1.6");
+    }
+
+    @Test
     void defaultKeyLengthForJca() {
         DetectionLocation testDetectionLocation =
                 new DetectionLocation("testfile", 1, 1, List.of("test"), () -> "Jca");

--- a/go/src/test/java/com/ibm/plugin/rules/detection/gocrypto/GoCryptoHKDFExpandTest.java
+++ b/go/src/test/java/com/ibm/plugin/rules/detection/gocrypto/GoCryptoHKDFExpandTest.java
@@ -149,7 +149,7 @@ class GoCryptoHKDFExpandTest extends TestBase {
             INode keyDerivationFunctionNode1 = nodes.get(1);
             assertThat(keyDerivationFunctionNode1.getKind()).isEqualTo(KeyDerivationFunction.class);
             assertThat(keyDerivationFunctionNode1.getChildren()).hasSize(2);
-            assertThat(keyDerivationFunctionNode1.asString()).isEqualTo("HKDF");
+            assertThat(keyDerivationFunctionNode1.asString()).isEqualTo("HKDF-SHA256");
 
             // KeyLength under KeyDerivationFunction
             INode keyLengthNode1 = keyDerivationFunctionNode1.getChildren().get(KeyLength.class);
@@ -161,7 +161,7 @@ class GoCryptoHKDFExpandTest extends TestBase {
             INode messageDigestNode1 =
                     keyDerivationFunctionNode1.getChildren().get(MessageDigest.class);
             assertThat(messageDigestNode1).isNotNull();
-            assertThat(messageDigestNode1.getChildren()).hasSize(2);
+            assertThat(messageDigestNode1.getChildren()).hasSize(4);
             assertThat(messageDigestNode1.asString()).isEqualTo("SHA256");
 
             // Digest under MessageDigest under KeyDerivationFunction
@@ -170,11 +170,23 @@ class GoCryptoHKDFExpandTest extends TestBase {
             assertThat(digestNode1.getChildren()).isEmpty();
             assertThat(digestNode1.asString()).isEqualTo("DIGEST");
 
+            // Oid under MessageDigest under KeyDerivationFunction
+            INode oidNode1 = messageDigestNode1.getChildren().get(Oid.class);
+            assertThat(oidNode1).isNotNull();
+            assertThat(oidNode1.getChildren()).isEmpty();
+            assertThat(oidNode1.asString()).isEqualTo("2.16.840.1.101.3.4.2.1");
+
             // DigestSize under MessageDigest under KeyDerivationFunction
             INode digestSizeNode1 = messageDigestNode1.getChildren().get(DigestSize.class);
             assertThat(digestSizeNode1).isNotNull();
             assertThat(digestSizeNode1.getChildren()).isEmpty();
             assertThat(digestSizeNode1.asString()).isEqualTo("256");
+
+            // BlockSize under MessageDigest under KeyDerivationFunction
+            INode blockSizeNode1 = messageDigestNode1.getChildren().get(BlockSize.class);
+            assertThat(blockSizeNode1).isNotNull();
+            assertThat(blockSizeNode1.getChildren()).isEmpty();
+            assertThat(blockSizeNode1.asString()).isEqualTo("512");
         }
     }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/Algorithm.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/Algorithm.java
@@ -36,7 +36,10 @@ public class Algorithm implements IAlgorithm {
     public Algorithm(
             @Nonnull IAlgorithm algorithm, @Nonnull final Class<? extends IPrimitive> asKind) {
         this.name = algorithm.getName();
-        this.children = algorithm.getChildren();
+        // The children map is defensively copied so callers, such as asKind reorganization,
+        // cannot mutate the source. Child INode instances remain shared; use deepCopy()
+        // for full isolation.
+        this.children = new HashMap<>(algorithm.getChildren());
         this.detectionLocation = algorithm.getDetectionContext();
         this.kind = asKind;
         this.origin = algorithm.getOrigin();
@@ -61,7 +64,7 @@ public class Algorithm implements IAlgorithm {
         this.origin = origin;
     }
 
-    private Algorithm(@Nonnull Algorithm algorithm) {
+    protected Algorithm(@Nonnull Algorithm algorithm) {
         this.children = new HashMap<>();
         this.kind = algorithm.kind;
         this.detectionLocation = algorithm.detectionLocation;
@@ -125,11 +128,24 @@ public class Algorithm implements IAlgorithm {
     @Nonnull
     @Override
     public INode deepCopy() {
-        Algorithm copy = new Algorithm(this);
+        Algorithm copy = this.shallowCopy();
         for (INode child : this.children.values()) {
             copy.children.put(child.getKind(), child.deepCopy());
         }
         return copy;
+    }
+
+    /**
+     * Creates a copy of this algorithm's metadata without copying children.
+     *
+     * <p>Subclasses must override this method to return their concrete type. Otherwise {@link
+     * #deepCopy()} will lose subtype identity by falling back to {@code Algorithm}.
+     *
+     * <p>Children are copied recursively by {@link #deepCopy()}.
+     */
+    @Nonnull
+    protected Algorithm shallowCopy() {
+        return new Algorithm(this);
     }
 
     public boolean is(@Nonnull final Class<? extends INode> type) {

--- a/mapper/src/main/java/com/ibm/mapper/model/EllipticCurveAlgorithm.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/EllipticCurveAlgorithm.java
@@ -41,4 +41,14 @@ public class EllipticCurveAlgorithm extends Algorithm
             @Nonnull EllipticCurveAlgorithm ellipticCurveAlgorithm) {
         super(ellipticCurveAlgorithm, asKind);
     }
+
+    private EllipticCurveAlgorithm(@Nonnull EllipticCurveAlgorithm ellipticCurveAlgorithm) {
+        super(ellipticCurveAlgorithm);
+    }
+
+    @Nonnull
+    @Override
+    protected EllipticCurveAlgorithm shallowCopy() {
+        return new EllipticCurveAlgorithm(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/PBES1.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/PBES1.java
@@ -79,4 +79,14 @@ public class PBES1 extends Algorithm implements PasswordBasedEncryption {
         }
         return hmacName.replace("HMAC-", "Hmac");
     }
+
+    private PBES1(@Nonnull PBES1 pBES1) {
+        super(pBES1);
+    }
+
+    @Nonnull
+    @Override
+    protected PBES1 shallowCopy() {
+        return new PBES1(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/PBES2.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/PBES2.java
@@ -49,4 +49,14 @@ public class PBES2 extends Algorithm implements PasswordBasedEncryption {
         this(mac.getDetectionContext());
         this.put(mac);
     }
+
+    private PBES2(@Nonnull PBES2 pBES2) {
+        super(pBES2);
+    }
+
+    @Nonnull
+    @Override
+    protected PBES2 shallowCopy() {
+        return new PBES2(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/PKCS12PBE.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/PKCS12PBE.java
@@ -47,4 +47,14 @@ public class PKCS12PBE extends Algorithm implements PasswordBasedEncryption {
         this(mac.getDetectionContext());
         this.put(mac);
     }
+
+    private PKCS12PBE(@Nonnull PKCS12PBE pKCS12PBE) {
+        super(pKCS12PBE);
+    }
+
+    @Nonnull
+    @Override
+    protected PKCS12PBE shallowCopy() {
+        return new PKCS12PBE(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/AES.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/AES.java
@@ -106,4 +106,14 @@ public final class AES extends Algorithm
         super(NAME, asKind, detectionLocation);
         this.put(BlockSize.ofDefault(128, detectionLocation));
     }
+
+    private AES(@Nonnull AES aES) {
+        super(aES);
+    }
+
+    @Nonnull
+    @Override
+    protected AES shallowCopy() {
+        return new AES(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/ANSIX931.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/ANSIX931.java
@@ -49,4 +49,14 @@ public final class ANSIX931 extends Algorithm implements Signature {
     public ANSIX931(@Nonnull DetectionLocation detectionLocation) {
         super(NAME, Signature.class, detectionLocation);
     }
+
+    private ANSIX931(@Nonnull ANSIX931 aNSIX931) {
+        super(aNSIX931);
+    }
+
+    @Nonnull
+    @Override
+    protected ANSIX931 shallowCopy() {
+        return new ANSIX931(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/ANSIX942.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/ANSIX942.java
@@ -49,4 +49,14 @@ public final class ANSIX942 extends Algorithm implements KeyDerivationFunction {
     public ANSIX942(@Nonnull DetectionLocation detectionLocation) {
         super(NAME, KeyDerivationFunction.class, detectionLocation);
     }
+
+    private ANSIX942(@Nonnull ANSIX942 aNSIX942) {
+        super(aNSIX942);
+    }
+
+    @Nonnull
+    @Override
+    protected ANSIX942 shallowCopy() {
+        return new ANSIX942(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/ANSIX963.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/ANSIX963.java
@@ -55,4 +55,14 @@ public final class ANSIX963 extends Algorithm implements KeyDerivationFunction {
         this(messageDigest.getDetectionContext());
         this.put(messageDigest);
     }
+
+    private ANSIX963(@Nonnull ANSIX963 aNSIX963) {
+        super(aNSIX963);
+    }
+
+    @Nonnull
+    @Override
+    protected ANSIX963 shallowCopy() {
+        return new ANSIX963(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/Aria.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/Aria.java
@@ -80,4 +80,14 @@ public final class Aria extends Algorithm implements BlockCipher, AuthenticatedE
     public Aria(@Nonnull final Class<? extends IPrimitive> asKind, @Nonnull Aria aria) {
         super(aria, asKind);
     }
+
+    private Aria(@Nonnull Aria aria) {
+        super(aria);
+    }
+
+    @Nonnull
+    @Override
+    protected Aria shallowCopy() {
+        return new Aria(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/BIKE.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/BIKE.java
@@ -49,4 +49,14 @@ public final class BIKE extends Algorithm implements KeyEncapsulationMechanism {
     public BIKE(@Nonnull DetectionLocation detectionLocation) {
         super(NAME, KeyEncapsulationMechanism.class, detectionLocation);
     }
+
+    private BIKE(@Nonnull BIKE bIKE) {
+        super(bIKE);
+    }
+
+    @Nonnull
+    @Override
+    protected BIKE shallowCopy() {
+        return new BIKE(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/Blowfish.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/Blowfish.java
@@ -81,4 +81,14 @@ public final class Blowfish extends Algorithm implements BlockCipher, Authentica
     public Blowfish(@Nonnull final Class<? extends IPrimitive> asKind, @Nonnull Blowfish blowfish) {
         super(blowfish, asKind);
     }
+
+    private Blowfish(@Nonnull Blowfish blowfish) {
+        super(blowfish);
+    }
+
+    @Nonnull
+    @Override
+    protected Blowfish shallowCopy() {
+        return new Blowfish(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/CMAC.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/CMAC.java
@@ -63,4 +63,14 @@ public final class CMAC extends Algorithm implements Mac {
                 .map(node -> ((IAlgorithm) node).getName() + "-" + this.name)
                 .orElse(this.name);
     }
+
+    private CMAC(@Nonnull CMAC cMAC) {
+        super(cMAC);
+    }
+
+    @Nonnull
+    @Override
+    protected CMAC shallowCopy() {
+        return new CMAC(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/Camellia.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/Camellia.java
@@ -65,4 +65,14 @@ public final class Camellia extends Algorithm
     public Camellia(@Nonnull final Class<? extends IPrimitive> asKind, @Nonnull Camellia camellia) {
         super(camellia, asKind);
     }
+
+    private Camellia(@Nonnull Camellia camellia) {
+        super(camellia);
+    }
+
+    @Nonnull
+    @Override
+    protected Camellia shallowCopy() {
+        return new Camellia(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/ChaCha20.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/ChaCha20.java
@@ -79,4 +79,14 @@ public final class ChaCha20 extends Algorithm implements StreamCipher {
     public ChaCha20(@Nonnull final Class<? extends IPrimitive> asKind, @Nonnull ChaCha20 chaCha20) {
         super(chaCha20, asKind);
     }
+
+    private ChaCha20(@Nonnull ChaCha20 chaCha20) {
+        super(chaCha20);
+    }
+
+    @Nonnull
+    @Override
+    protected ChaCha20 shallowCopy() {
+        return new ChaCha20(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/ChaCha20Poly1305.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/ChaCha20Poly1305.java
@@ -35,4 +35,14 @@ public final class ChaCha20Poly1305 extends Algorithm implements AuthenticatedEn
         super(new ChaCha20(detectionLocation), AuthenticatedEncryption.class);
         this.put(new Poly1305(detectionLocation));
     }
+
+    private ChaCha20Poly1305(@Nonnull ChaCha20Poly1305 chaCha20Poly1305) {
+        super(chaCha20Poly1305);
+    }
+
+    @Nonnull
+    @Override
+    protected ChaCha20Poly1305 shallowCopy() {
+        return new ChaCha20Poly1305(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/ClassicMcEliece.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/ClassicMcEliece.java
@@ -50,4 +50,14 @@ public final class ClassicMcEliece extends Algorithm implements KeyEncapsulation
     public ClassicMcEliece(@Nonnull DetectionLocation detectionLocation) {
         super(NAME, KeyEncapsulationMechanism.class, detectionLocation);
     }
+
+    private ClassicMcEliece(@Nonnull ClassicMcEliece classicMcEliece) {
+        super(classicMcEliece);
+    }
+
+    @Nonnull
+    @Override
+    protected ClassicMcEliece shallowCopy() {
+        return new ClassicMcEliece(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/ConcatenationKDF.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/ConcatenationKDF.java
@@ -56,4 +56,14 @@ public final class ConcatenationKDF extends Algorithm implements KeyDerivationFu
         this(messageDigest.getDetectionContext());
         this.put(messageDigest);
     }
+
+    private ConcatenationKDF(@Nonnull ConcatenationKDF concatenationKDF) {
+        super(concatenationKDF);
+    }
+
+    @Nonnull
+    @Override
+    protected ConcatenationKDF shallowCopy() {
+        return new ConcatenationKDF(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/DES.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/DES.java
@@ -106,4 +106,14 @@ public final class DES extends Algorithm implements BlockCipher, Mac {
     public DES(@Nonnull final Class<? extends IPrimitive> asKind, @Nonnull DES des) {
         super(des, asKind);
     }
+
+    private DES(@Nonnull DES dES) {
+        super(dES);
+    }
+
+    @Nonnull
+    @Override
+    protected DES shallowCopy() {
+        return new DES(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/DESede.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/DESede.java
@@ -95,4 +95,14 @@ public final class DESede extends Algorithm implements BlockCipher, KeyWrap, Mac
     public DESede(@Nonnull final Class<? extends IPrimitive> asKind, @Nonnull DESede desEde) {
         super(desEde, asKind);
     }
+
+    private DESede(@Nonnull DESede dESede) {
+        super(dESede);
+    }
+
+    @Nonnull
+    @Override
+    protected DESede shallowCopy() {
+        return new DESede(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/DH.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/DH.java
@@ -71,4 +71,14 @@ public final class DH extends Algorithm implements Signature, KeyAgreement, Publ
         super(NAME, asKind, detectionLocation);
         this.put(new Oid("1.2.840.113549.1.3.1", detectionLocation));
     }
+
+    private DH(@Nonnull DH dH) {
+        super(dH);
+    }
+
+    @Nonnull
+    @Override
+    protected DH shallowCopy() {
+        return new DH(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/DSA.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/DSA.java
@@ -46,4 +46,14 @@ public class DSA extends Algorithm implements Signature {
         this(messageDigest.getDetectionContext());
         this.put(messageDigest);
     }
+
+    protected DSA(@Nonnull DSA dSA) {
+        super(dSA);
+    }
+
+    @Nonnull
+    @Override
+    protected DSA shallowCopy() {
+        return new DSA(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/DSS.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/DSS.java
@@ -35,4 +35,14 @@ public final class DSS extends DSA {
     public DSS(@Nonnull DetectionLocation detectionLocation) {
         super(detectionLocation);
     }
+
+    private DSS(@Nonnull DSS dSS) {
+        super(dSS);
+    }
+
+    @Nonnull
+    @Override
+    protected DSS shallowCopy() {
+        return new DSS(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/DSTU4145.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/DSTU4145.java
@@ -48,4 +48,14 @@ public final class DSTU4145 extends Algorithm implements Signature {
     public DSTU4145(@Nonnull DetectionLocation detectionLocation) {
         super(NAME, Signature.class, detectionLocation);
     }
+
+    private DSTU4145(@Nonnull DSTU4145 dSTU4145) {
+        super(dSTU4145);
+    }
+
+    @Nonnull
+    @Override
+    protected DSTU4145 shallowCopy() {
+        return new DSTU4145(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/Dilithium.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/Dilithium.java
@@ -64,4 +64,14 @@ public class Dilithium extends Algorithm implements Signature {
                 new ParameterSetIdentifier(
                         String.valueOf(parameterSetIdentifier), detectionLocation));
     }
+
+    private Dilithium(@Nonnull Dilithium dilithium) {
+        super(dilithium);
+    }
+
+    @Nonnull
+    @Override
+    protected Dilithium shallowCopy() {
+        return new Dilithium(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/ECCPWD.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/ECCPWD.java
@@ -48,4 +48,14 @@ public final class ECCPWD extends Algorithm implements KeyAgreement {
     public ECCPWD(@Nonnull DetectionLocation detectionLocation) {
         super(NAME, KeyAgreement.class, detectionLocation);
     }
+
+    private ECCPWD(@Nonnull ECCPWD eCCPWD) {
+        super(eCCPWD);
+    }
+
+    @Nonnull
+    @Override
+    protected ECCPWD shallowCopy() {
+        return new ECCPWD(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/ECDH.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/ECDH.java
@@ -56,4 +56,14 @@ public final class ECDH extends Algorithm implements KeyAgreement {
         this(ellipticCurve.getDetectionContext());
         this.put(ellipticCurve);
     }
+
+    private ECDH(@Nonnull ECDH eCDH) {
+        super(eCDH);
+    }
+
+    @Nonnull
+    @Override
+    protected ECDH shallowCopy() {
+        return new ECDH(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/ECDSA.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/ECDSA.java
@@ -64,4 +64,14 @@ public final class ECDSA extends Algorithm implements Signature {
         this(detectionLocation);
         this.put(ellipticCurve);
     }
+
+    private ECDSA(@Nonnull ECDSA eCDSA) {
+        super(eCDSA);
+    }
+
+    @Nonnull
+    @Override
+    protected ECDSA shallowCopy() {
+        return new ECDSA(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/ECMQV.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/ECMQV.java
@@ -57,4 +57,14 @@ public final class ECMQV extends Algorithm implements KeyAgreement {
         this(detectionLocation);
         this.put(ellipticCurve);
     }
+
+    private ECMQV(@Nonnull ECMQV eCMQV) {
+        super(eCMQV);
+    }
+
+    @Nonnull
+    @Override
+    protected ECMQV shallowCopy() {
+        return new ECMQV(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/ECNR.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/ECNR.java
@@ -58,4 +58,14 @@ public final class ECNR extends Algorithm implements Signature {
         this(detectionLocation);
         this.put(ellipticCurve);
     }
+
+    private ECNR(@Nonnull ECNR eCNR) {
+        super(eCNR);
+    }
+
+    @Nonnull
+    @Override
+    protected ECNR shallowCopy() {
+        return new ECNR(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/Ed25519.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/Ed25519.java
@@ -52,4 +52,14 @@ public final class Ed25519 extends EdDSA implements Signature {
         this.put(new SHA2(512, detectionLocation));
         this.put(new Oid("1.3.101.112", detectionLocation));
     }
+
+    private Ed25519(@Nonnull Ed25519 ed25519) {
+        super(ed25519);
+    }
+
+    @Nonnull
+    @Override
+    protected Ed25519 shallowCopy() {
+        return new Ed25519(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/Ed448.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/Ed448.java
@@ -53,4 +53,14 @@ public final class Ed448 extends EdDSA implements Signature {
         this.put(new SHAKE(256, detectionLocation));
         this.put(new Oid("1.3.101.113", detectionLocation));
     }
+
+    private Ed448(@Nonnull Ed448 ed448) {
+        super(ed448);
+    }
+
+    @Nonnull
+    @Override
+    protected Ed448 shallowCopy() {
+        return new Ed448(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/EdDSA.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/EdDSA.java
@@ -34,4 +34,14 @@ public class EdDSA extends Algorithm implements Signature {
     public EdDSA(@Nonnull DetectionLocation detectionLocation) {
         this(NAME, detectionLocation);
     }
+
+    protected EdDSA(@Nonnull EdDSA edDSA) {
+        super(edDSA);
+    }
+
+    @Nonnull
+    @Override
+    protected EdDSA shallowCopy() {
+        return new EdDSA(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/ElGamal.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/ElGamal.java
@@ -62,4 +62,14 @@ public final class ElGamal extends Algorithm implements PublicKeyEncryption, Sig
     public ElGamal(@Nonnull final Class<? extends IPrimitive> asKind, @Nonnull ElGamal elGamal) {
         super(elGamal, asKind);
     }
+
+    private ElGamal(@Nonnull ElGamal elGamal) {
+        super(elGamal);
+    }
+
+    @Nonnull
+    @Override
+    protected ElGamal shallowCopy() {
+        return new ElGamal(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/Falcon.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/Falcon.java
@@ -64,4 +64,14 @@ public class Falcon extends Algorithm implements Signature {
                 new ParameterSetIdentifier(
                         String.valueOf(parameterSetIdentifier), detectionLocation));
     }
+
+    private Falcon(@Nonnull Falcon falcon) {
+        super(falcon);
+    }
+
+    @Nonnull
+    @Override
+    protected Falcon shallowCopy() {
+        return new Falcon(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/Fernet.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/Fernet.java
@@ -62,4 +62,14 @@ public final class Fernet extends Algorithm implements AuthenticatedEncryption {
     public Fernet(@Nonnull final Class<? extends IPrimitive> asKind, @Nonnull Fernet fernet) {
         super(fernet, asKind);
     }
+
+    private Fernet(@Nonnull Fernet fernet) {
+        super(fernet);
+    }
+
+    @Nonnull
+    @Override
+    protected Fernet shallowCopy() {
+        return new Fernet(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/FrodoKEM.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/FrodoKEM.java
@@ -49,4 +49,14 @@ public final class FrodoKEM extends Algorithm implements KeyEncapsulationMechani
     public FrodoKEM(@Nonnull DetectionLocation detectionLocation) {
         super(NAME, KeyEncapsulationMechanism.class, detectionLocation);
     }
+
+    private FrodoKEM(@Nonnull FrodoKEM frodoKEM) {
+        super(frodoKEM);
+    }
+
+    @Nonnull
+    @Override
+    protected FrodoKEM shallowCopy() {
+        return new FrodoKEM(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/GMSS.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/GMSS.java
@@ -50,4 +50,14 @@ public class GMSS extends Algorithm implements Signature {
     public GMSS(@Nonnull DetectionLocation detectionLocation) {
         super(NAME, Signature.class, detectionLocation);
     }
+
+    private GMSS(@Nonnull GMSS gMSS) {
+        super(gMSS);
+    }
+
+    @Nonnull
+    @Override
+    protected GMSS shallowCopy() {
+        return new GMSS(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/GeMSS.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/GeMSS.java
@@ -65,4 +65,14 @@ public class GeMSS extends Algorithm implements Signature {
                 new ParameterSetIdentifier(
                         String.valueOf(parameterSetIdentifier), detectionLocation));
     }
+
+    private GeMSS(@Nonnull GeMSS geMSS) {
+        super(geMSS);
+    }
+
+    @Nonnull
+    @Override
+    protected GeMSS shallowCopy() {
+        return new GeMSS(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/HC.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/HC.java
@@ -67,4 +67,14 @@ public final class HC extends Algorithm implements StreamCipher {
     public HC(@Nonnull final Class<? extends IPrimitive> asKind, @Nonnull HC hc) {
         super(hc, asKind);
     }
+
+    private HC(@Nonnull HC hC) {
+        super(hC);
+    }
+
+    @Nonnull
+    @Override
+    protected HC shallowCopy() {
+        return new HC(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/HKDF.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/HKDF.java
@@ -64,4 +64,14 @@ public final class HKDF extends Algorithm implements KeyDerivationFunction {
                 .map(digest -> this.name + "-" + ((IAlgorithm) digest).getName())
                 .orElse(this.name);
     }
+
+    private HKDF(@Nonnull HKDF hKDF) {
+        super(hKDF);
+    }
+
+    @Nonnull
+    @Override
+    protected HKDF shallowCopy() {
+        return new HKDF(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/HMAC.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/HMAC.java
@@ -62,4 +62,14 @@ public final class HMAC extends Algorithm implements Mac {
                 .map(digest -> this.name + "-" + ((IAlgorithm) digest).getName())
                 .orElse(this.name);
     }
+
+    private HMAC(@Nonnull HMAC hMAC) {
+        super(hMAC);
+    }
+
+    @Nonnull
+    @Override
+    protected HMAC shallowCopy() {
+        return new HMAC(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/HQC.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/HQC.java
@@ -69,4 +69,14 @@ public final class HQC extends Algorithm implements KeyEncapsulationMechanism, P
             @Nonnull DetectionLocation detectionLocation) {
         super(NAME, asKind, detectionLocation);
     }
+
+    private HQC(@Nonnull HQC hQC) {
+        super(hQC);
+    }
+
+    @Nonnull
+    @Override
+    protected HQC shallowCopy() {
+        return new HQC(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/HSS.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/HSS.java
@@ -50,4 +50,14 @@ public class HSS extends Algorithm implements Signature {
     public HSS(@Nonnull DetectionLocation detectionLocation) {
         super(NAME, Signature.class, detectionLocation);
     }
+
+    private HSS(@Nonnull HSS hSS) {
+        super(hSS);
+    }
+
+    @Nonnull
+    @Override
+    protected HSS shallowCopy() {
+        return new HSS(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/HarakaV2.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/HarakaV2.java
@@ -80,4 +80,14 @@ public final class HarakaV2 extends Algorithm implements MessageDigest {
     public HarakaV2(@Nonnull final Class<? extends IPrimitive> asKind, @Nonnull HarakaV2 haraka) {
         super(haraka, asKind);
     }
+
+    private HarakaV2(@Nonnull HarakaV2 harakaV2) {
+        super(harakaV2);
+    }
+
+    @Nonnull
+    @Override
+    protected HarakaV2 shallowCopy() {
+        return new HarakaV2(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/IDEA.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/IDEA.java
@@ -60,4 +60,14 @@ public final class IDEA extends Algorithm implements BlockCipher {
     public IDEA(@Nonnull final Class<? extends IPrimitive> asKind, @Nonnull IDEA idea) {
         super(idea, asKind);
     }
+
+    private IDEA(@Nonnull IDEA iDEA) {
+        super(iDEA);
+    }
+
+    @Nonnull
+    @Override
+    protected IDEA shallowCopy() {
+        return new IDEA(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/ISAAC.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/ISAAC.java
@@ -55,4 +55,14 @@ public final class ISAAC extends Algorithm implements StreamCipher, Pseudorandom
     public ISAAC(@Nonnull final Class<? extends IPrimitive> asKind, @Nonnull ISAAC isaac) {
         super(isaac, asKind);
     }
+
+    private ISAAC(@Nonnull ISAAC iSAAC) {
+        super(iSAAC);
+    }
+
+    @Nonnull
+    @Override
+    protected ISAAC shallowCopy() {
+        return new ISAAC(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/ISO9796.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/ISO9796.java
@@ -53,4 +53,14 @@ public class ISO9796 extends Algorithm implements Signature, ProbabilisticSignat
     public ISO9796(@Nonnull final Class<? extends IPrimitive> asKind, @Nonnull ISO9796 iso) {
         super(iso, asKind);
     }
+
+    private ISO9796(@Nonnull ISO9796 iSO9796) {
+        super(iSO9796);
+    }
+
+    @Nonnull
+    @Override
+    protected ISO9796 shallowCopy() {
+        return new ISO9796(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/KDF1.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/KDF1.java
@@ -56,4 +56,14 @@ public final class KDF1 extends Algorithm implements KeyDerivationFunction {
         this(messageDigest.getDetectionContext());
         this.put(messageDigest);
     }
+
+    private KDF1(@Nonnull KDF1 kDF1) {
+        super(kDF1);
+    }
+
+    @Nonnull
+    @Override
+    protected KDF1 shallowCopy() {
+        return new KDF1(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/KDF2.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/KDF2.java
@@ -58,4 +58,14 @@ public final class KDF2 extends Algorithm implements KeyDerivationFunction {
         this(messageDigest.getDetectionContext());
         this.put(messageDigest);
     }
+
+    private KDF2(@Nonnull KDF2 kDF2) {
+        super(kDF2);
+    }
+
+    @Nonnull
+    @Override
+    protected KDF2 shallowCopy() {
+        return new KDF2(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/KDFCounter.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/KDFCounter.java
@@ -55,4 +55,14 @@ public final class KDFCounter extends Algorithm implements KeyDerivationFunction
         this(mac.getDetectionContext());
         this.put(mac);
     }
+
+    private KDFCounter(@Nonnull KDFCounter kDFCounter) {
+        super(kDFCounter);
+    }
+
+    @Nonnull
+    @Override
+    protected KDFCounter shallowCopy() {
+        return new KDFCounter(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/KDFDoublePipeline.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/KDFDoublePipeline.java
@@ -55,4 +55,14 @@ public final class KDFDoublePipeline extends Algorithm implements KeyDerivationF
         this(mac.getDetectionContext());
         this.put(mac);
     }
+
+    private KDFDoublePipeline(@Nonnull KDFDoublePipeline kDFDoublePipeline) {
+        super(kDFDoublePipeline);
+    }
+
+    @Nonnull
+    @Override
+    protected KDFDoublePipeline shallowCopy() {
+        return new KDFDoublePipeline(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/KDFFeedback.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/KDFFeedback.java
@@ -55,4 +55,14 @@ public final class KDFFeedback extends Algorithm implements KeyDerivationFunctio
         this(mac.getDetectionContext());
         this.put(mac);
     }
+
+    private KDFFeedback(@Nonnull KDFFeedback kDFFeedback) {
+        super(kDFFeedback);
+    }
+
+    @Nonnull
+    @Override
+    protected KDFFeedback shallowCopy() {
+        return new KDFFeedback(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/KDFSession.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/KDFSession.java
@@ -56,4 +56,14 @@ public final class KDFSession extends Algorithm implements KeyDerivationFunction
         this(messageDigest.getDetectionContext());
         this.put(messageDigest);
     }
+
+    private KDFSession(@Nonnull KDFSession kDFSession) {
+        super(kDFSession);
+    }
+
+    @Nonnull
+    @Override
+    protected KDFSession shallowCopy() {
+        return new KDFSession(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/KMAC.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/KMAC.java
@@ -84,4 +84,14 @@ public final class KMAC extends Algorithm implements MessageDigest {
     public KMAC(@Nonnull final Class<? extends IPrimitive> asKind, @Nonnull KMAC kmac) {
         super(kmac, asKind);
     }
+
+    private KMAC(@Nonnull KMAC kMAC) {
+        super(kMAC);
+    }
+
+    @Nonnull
+    @Override
+    protected KMAC shallowCopy() {
+        return new KMAC(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/Kalyna.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/Kalyna.java
@@ -84,4 +84,14 @@ public final class Kalyna extends Algorithm implements BlockCipher, Mac, KeyWrap
     public Kalyna(@Nonnull final Class<? extends IPrimitive> asKind, @Nonnull Kalyna kalyna) {
         super(kalyna, asKind);
     }
+
+    private Kalyna(@Nonnull Kalyna kalyna) {
+        super(kalyna);
+    }
+
+    @Nonnull
+    @Override
+    protected Kalyna shallowCopy() {
+        return new Kalyna(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/KangarooTwelve.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/KangarooTwelve.java
@@ -58,4 +58,14 @@ public final class KangarooTwelve extends Algorithm implements ExtendableOutputF
         this(detectionLocation);
         this.put(new DigestSize(digestSize, detectionLocation));
     }
+
+    private KangarooTwelve(@Nonnull KangarooTwelve kangarooTwelve) {
+        super(kangarooTwelve);
+    }
+
+    @Nonnull
+    @Override
+    protected KangarooTwelve shallowCopy() {
+        return new KangarooTwelve(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/Keccak.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/Keccak.java
@@ -55,4 +55,14 @@ public final class Keccak extends Algorithm implements MessageDigest, Authentica
     public Keccak(@Nonnull final Class<? extends IPrimitive> asKind, @Nonnull Keccak keccak) {
         super(keccak, asKind);
     }
+
+    private Keccak(@Nonnull Keccak keccak) {
+        super(keccak);
+    }
+
+    @Nonnull
+    @Override
+    protected Keccak shallowCopy() {
+        return new Keccak(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/Kerberos.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/Kerberos.java
@@ -52,4 +52,14 @@ public final class Kerberos extends Algorithm implements KeyAgreement {
     public Kerberos(int version, @Nonnull DetectionLocation detectionLocation) {
         super(NAME + version, KeyAgreement.class, detectionLocation);
     }
+
+    private Kerberos(@Nonnull Kerberos kerberos) {
+        super(kerberos);
+    }
+
+    @Nonnull
+    @Override
+    protected Kerberos shallowCopy() {
+        return new Kerberos(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/Kupyna.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/Kupyna.java
@@ -89,4 +89,14 @@ public final class Kupyna extends Algorithm implements MessageDigest {
     public Kupyna(@Nonnull final Class<? extends IPrimitive> asKind, @Nonnull Kupyna kupyna) {
         super(kupyna, asKind);
     }
+
+    private Kupyna(@Nonnull Kupyna kupyna) {
+        super(kupyna);
+    }
+
+    @Nonnull
+    @Override
+    protected Kupyna shallowCopy() {
+        return new Kupyna(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/LEA.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/LEA.java
@@ -81,4 +81,14 @@ public final class LEA extends Algorithm implements BlockCipher {
     public LEA(@Nonnull final Class<? extends IPrimitive> asKind, @Nonnull LEA lea) {
         super(lea, asKind);
     }
+
+    private LEA(@Nonnull LEA lEA) {
+        super(lEA);
+    }
+
+    @Nonnull
+    @Override
+    protected LEA shallowCopy() {
+        return new LEA(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/LMS.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/LMS.java
@@ -69,4 +69,14 @@ public final class LMS extends Algorithm implements Signature, MessageDigest {
             @Nonnull DetectionLocation detectionLocation) {
         super(NAME, asKind, detectionLocation);
     }
+
+    private LMS(@Nonnull LMS lMS) {
+        super(lMS);
+    }
+
+    @Nonnull
+    @Override
+    protected LMS shallowCopy() {
+        return new LMS(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/MD2.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/MD2.java
@@ -59,4 +59,14 @@ public final class MD2 extends Algorithm implements MessageDigest {
         this.put(BlockSize.ofDefault(128, detectionLocation));
         this.put(new DigestSize(128, detectionLocation));
     }
+
+    private MD2(@Nonnull MD2 mD2) {
+        super(mD2);
+    }
+
+    @Nonnull
+    @Override
+    protected MD2 shallowCopy() {
+        return new MD2(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/MD4.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/MD4.java
@@ -59,4 +59,14 @@ public final class MD4 extends Algorithm implements MessageDigest {
         this.put(BlockSize.ofDefault(512, detectionLocation));
         this.put(new DigestSize(128, detectionLocation));
     }
+
+    private MD4(@Nonnull MD4 mD4) {
+        super(mD4);
+    }
+
+    @Nonnull
+    @Override
+    protected MD4 shallowCopy() {
+        return new MD4(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/MD5.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/MD5.java
@@ -59,4 +59,14 @@ public final class MD5 extends Algorithm implements MessageDigest {
         this.put(BlockSize.ofDefault(512, detectionLocation));
         this.put(new DigestSize(128, detectionLocation));
     }
+
+    private MD5(@Nonnull MD5 mD5) {
+        super(mD5);
+    }
+
+    @Nonnull
+    @Override
+    protected MD5 shallowCopy() {
+        return new MD5(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/MGF1.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/MGF1.java
@@ -37,4 +37,14 @@ public final class MGF1 extends Algorithm implements MaskGenerationFunction {
         this(messageDigest.getDetectionContext());
         this.put(messageDigest);
     }
+
+    private MGF1(@Nonnull MGF1 mGF1) {
+        super(mGF1);
+    }
+
+    @Nonnull
+    @Override
+    protected MGF1 shallowCopy() {
+        return new MGF1(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/MLDSA.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/MLDSA.java
@@ -88,4 +88,14 @@ public class MLDSA extends Algorithm implements Signature {
                 new ParameterSetIdentifier(
                         String.valueOf(parameterSetIdentifier), preHash.getDetectionContext()));
     }
+
+    private MLDSA(@Nonnull MLDSA mLDSA) {
+        super(mLDSA);
+    }
+
+    @Nonnull
+    @Override
+    protected MLDSA shallowCopy() {
+        return new MLDSA(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/MLKEM.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/MLKEM.java
@@ -73,4 +73,14 @@ public final class MLKEM extends Algorithm implements KeyEncapsulationMechanism 
                 new ParameterSetIdentifier(
                         String.valueOf(parameterSetIdentifier), detectionLocation));
     }
+
+    private MLKEM(@Nonnull MLKEM mLKEM) {
+        super(mLKEM);
+    }
+
+    @Nonnull
+    @Override
+    protected MLKEM shallowCopy() {
+        return new MLKEM(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/MQV.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/MQV.java
@@ -50,4 +50,14 @@ public final class MQV extends Algorithm implements KeyAgreement {
     public MQV(@Nonnull DetectionLocation detectionLocation) {
         super(NAME, KeyAgreement.class, detectionLocation);
     }
+
+    private MQV(@Nonnull MQV mQV) {
+        super(mQV);
+    }
+
+    @Nonnull
+    @Override
+    protected MQV shallowCopy() {
+        return new MQV(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/MarsupilamiFourteen.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/MarsupilamiFourteen.java
@@ -58,4 +58,14 @@ public final class MarsupilamiFourteen extends Algorithm implements MessageDiges
         this(detectionLocation);
         this.put(new DigestSize(digestSize, detectionLocation));
     }
+
+    private MarsupilamiFourteen(@Nonnull MarsupilamiFourteen marsupilamiFourteen) {
+        super(marsupilamiFourteen);
+    }
+
+    @Nonnull
+    @Override
+    protected MarsupilamiFourteen shallowCopy() {
+        return new MarsupilamiFourteen(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/NOEKEON.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/NOEKEON.java
@@ -74,4 +74,14 @@ public final class NOEKEON extends Algorithm implements BlockCipher {
     public NOEKEON(@Nonnull final Class<? extends IPrimitive> asKind, @Nonnull NOEKEON noekeon) {
         super(noekeon, asKind);
     }
+
+    private NOEKEON(@Nonnull NOEKEON nOEKEON) {
+        super(nOEKEON);
+    }
+
+    @Nonnull
+    @Override
+    protected NOEKEON shallowCopy() {
+        return new NOEKEON(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/NaccacheStern.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/NaccacheStern.java
@@ -63,4 +63,14 @@ public final class NaccacheStern extends Algorithm implements PublicKeyEncryptio
             @Nonnull NaccacheStern naccacheStern) {
         super(naccacheStern, asKind);
     }
+
+    private NaccacheStern(@Nonnull NaccacheStern naccacheStern) {
+        super(naccacheStern);
+    }
+
+    @Nonnull
+    @Override
+    protected NaccacheStern shallowCopy() {
+        return new NaccacheStern(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/PBKDF1.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/PBKDF1.java
@@ -79,4 +79,14 @@ public final class PBKDF1 extends Algorithm implements PasswordBasedKeyDerivatio
     public PBKDF1(@Nonnull DetectionLocation detectionLocation) {
         super(NAME, PasswordBasedKeyDerivationFunction.class, detectionLocation);
     }
+
+    private PBKDF1(@Nonnull PBKDF1 pBKDF1) {
+        super(pBKDF1);
+    }
+
+    @Nonnull
+    @Override
+    protected PBKDF1 shallowCopy() {
+        return new PBKDF1(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/PBKDF2.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/PBKDF2.java
@@ -79,4 +79,14 @@ public final class PBKDF2 extends Algorithm implements PasswordBasedKeyDerivatio
     public PBKDF2(@Nonnull DetectionLocation detectionLocation) {
         super(NAME, PasswordBasedKeyDerivationFunction.class, detectionLocation);
     }
+
+    private PBKDF2(@Nonnull PBKDF2 pBKDF2) {
+        super(pBKDF2);
+    }
+
+    @Nonnull
+    @Override
+    protected PBKDF2 shallowCopy() {
+        return new PBKDF2(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/PSK.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/PSK.java
@@ -48,4 +48,14 @@ public final class PSK extends Algorithm implements KeyAgreement {
     public PSK(@Nonnull DetectionLocation detectionLocation) {
         super(NAME, KeyAgreement.class, detectionLocation);
     }
+
+    private PSK(@Nonnull PSK pSK) {
+        super(pSK);
+    }
+
+    @Nonnull
+    @Override
+    protected PSK shallowCopy() {
+        return new PSK(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/ParallelHash.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/ParallelHash.java
@@ -55,4 +55,14 @@ public final class ParallelHash extends Algorithm implements ExtendableOutputFun
         this(detectionLocation);
         this.put(new DigestSize(digestSize, detectionLocation));
     }
+
+    private ParallelHash(@Nonnull ParallelHash parallelHash) {
+        super(parallelHash);
+    }
+
+    @Nonnull
+    @Override
+    protected ParallelHash shallowCopy() {
+        return new ParallelHash(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/Picnic.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/Picnic.java
@@ -63,4 +63,14 @@ public class Picnic extends Algorithm implements Signature {
         this(detectionLocation);
         this.put(new ParameterSetIdentifier(parameterSetIdentifier, detectionLocation));
     }
+
+    private Picnic(@Nonnull Picnic picnic) {
+        super(picnic);
+    }
+
+    @Nonnull
+    @Override
+    protected Picnic shallowCopy() {
+        return new Picnic(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/Poly1305.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/Poly1305.java
@@ -53,4 +53,14 @@ public final class Poly1305 extends Algorithm implements MessageDigest {
     public Poly1305(@Nonnull final Class<? extends IPrimitive> asKind, @Nonnull Poly1305 poly1305) {
         super(poly1305, asKind);
     }
+
+    private Poly1305(@Nonnull Poly1305 poly1305) {
+        super(poly1305);
+    }
+
+    @Nonnull
+    @Override
+    protected Poly1305 shallowCopy() {
+        return new Poly1305(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/QTESLA.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/QTESLA.java
@@ -49,4 +49,14 @@ public class QTESLA extends Algorithm implements Signature {
     public QTESLA(@Nonnull DetectionLocation detectionLocation) {
         super(NAME, Signature.class, detectionLocation);
     }
+
+    private QTESLA(@Nonnull QTESLA qTESLA) {
+        super(qTESLA);
+    }
+
+    @Nonnull
+    @Override
+    protected QTESLA shallowCopy() {
+        return new QTESLA(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/RC2.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/RC2.java
@@ -80,4 +80,14 @@ public final class RC2 extends Algorithm implements BlockCipher, KeyWrap {
     public RC2(@Nonnull final Class<? extends IPrimitive> asKind, @Nonnull RC2 rc2) {
         super(rc2, asKind);
     }
+
+    private RC2(@Nonnull RC2 rC2) {
+        super(rC2);
+    }
+
+    @Nonnull
+    @Override
+    protected RC2 shallowCopy() {
+        return new RC2(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/RC4.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/RC4.java
@@ -80,4 +80,14 @@ public final class RC4 extends Algorithm implements StreamCipher {
     public RC4(@Nonnull final Class<? extends IPrimitive> asKind, @Nonnull RC4 rc4) {
         super(rc4, asKind);
     }
+
+    private RC4(@Nonnull RC4 rC4) {
+        super(rC4);
+    }
+
+    @Nonnull
+    @Override
+    protected RC4 shallowCopy() {
+        return new RC4(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/RC5.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/RC5.java
@@ -82,4 +82,14 @@ public final class RC5 extends Algorithm implements BlockCipher, AuthenticatedEn
     public RC5(@Nonnull final Class<? extends IPrimitive> asKind, @Nonnull RC5 rc5) {
         super(rc5, asKind);
     }
+
+    private RC5(@Nonnull RC5 rC5) {
+        super(rC5);
+    }
+
+    @Nonnull
+    @Override
+    protected RC5 shallowCopy() {
+        return new RC5(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/RC6.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/RC6.java
@@ -83,4 +83,14 @@ public final class RC6 extends Algorithm implements BlockCipher, AuthenticatedEn
     public RC6(@Nonnull final Class<? extends IPrimitive> asKind, @Nonnull RC6 rc6) {
         super(rc6, asKind);
     }
+
+    private RC6(@Nonnull RC6 rC6) {
+        super(rC6);
+    }
+
+    @Nonnull
+    @Override
+    protected RC6 shallowCopy() {
+        return new RC6(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/RFC3211Wrap.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/RFC3211Wrap.java
@@ -49,4 +49,14 @@ public class RFC3211Wrap extends Algorithm implements KeyWrap {
     public RFC3211Wrap(@Nonnull DetectionLocation detectionLocation) {
         super(NAME, KeyWrap.class, detectionLocation);
     }
+
+    private RFC3211Wrap(@Nonnull RFC3211Wrap rFC3211Wrap) {
+        super(rFC3211Wrap);
+    }
+
+    @Nonnull
+    @Override
+    protected RFC3211Wrap shallowCopy() {
+        return new RFC3211Wrap(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/RIPEMD.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/RIPEMD.java
@@ -72,4 +72,14 @@ public final class RIPEMD extends Algorithm implements MessageDigest {
         this(detectionLocation);
         this.put(new DigestSize(digestSize, detectionLocation));
     }
+
+    private RIPEMD(@Nonnull RIPEMD rIPEMD) {
+        super(rIPEMD);
+    }
+
+    @Nonnull
+    @Override
+    protected RIPEMD shallowCopy() {
+        return new RIPEMD(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/RSA.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/RSA.java
@@ -96,16 +96,12 @@ public final class RSA extends Algorithm implements KeyAgreement, Signature, Pub
     }
 
     private RSA(@Nonnull final RSA rsa) {
-        super(rsa.name, rsa.kind, rsa.detectionLocation);
+        super(rsa);
     }
 
     @Nonnull
     @Override
-    public INode deepCopy() {
-        RSA copy = new RSA(this);
-        for (INode child : this.children.values()) {
-            copy.children.put(child.getKind(), child.deepCopy());
-        }
-        return copy;
+    protected RSA shallowCopy() {
+        return new RSA(this);
     }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/RSAKEM.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/RSAKEM.java
@@ -50,4 +50,14 @@ public final class RSAKEM extends Algorithm implements KeyEncapsulationMechanism
     public RSAKEM(@Nonnull DetectionLocation detectionLocation) {
         super(NAME, KeyEncapsulationMechanism.class, detectionLocation);
     }
+
+    private RSAKEM(@Nonnull RSAKEM rSAKEM) {
+        super(rSAKEM);
+    }
+
+    @Nonnull
+    @Override
+    protected RSAKEM shallowCopy() {
+        return new RSAKEM(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/RSAssaPSS.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/RSAssaPSS.java
@@ -47,4 +47,14 @@ public final class RSAssaPSS extends Algorithm implements ProbabilisticSignature
     public RSAssaPSS(@Nonnull DetectionLocation detectionLocation) {
         super("RSASSA-PSS", ProbabilisticSignatureScheme.class, detectionLocation);
     }
+
+    private RSAssaPSS(@Nonnull RSAssaPSS rSAssaPSS) {
+        super(rSAssaPSS);
+    }
+
+    @Nonnull
+    @Override
+    protected RSAssaPSS shallowCopy() {
+        return new RSAssaPSS(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/Rainbow.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/Rainbow.java
@@ -49,4 +49,14 @@ public class Rainbow extends Algorithm implements Signature {
     public Rainbow(@Nonnull DetectionLocation detectionLocation) {
         super(NAME, Signature.class, detectionLocation);
     }
+
+    private Rainbow(@Nonnull Rainbow rainbow) {
+        super(rainbow);
+    }
+
+    @Nonnull
+    @Override
+    protected Rainbow shallowCopy() {
+        return new Rainbow(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/SABER.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/SABER.java
@@ -49,4 +49,14 @@ public final class SABER extends Algorithm implements KeyEncapsulationMechanism 
     public SABER(@Nonnull DetectionLocation detectionLocation) {
         super(NAME, KeyEncapsulationMechanism.class, detectionLocation);
     }
+
+    private SABER(@Nonnull SABER sABER) {
+        super(sABER);
+    }
+
+    @Nonnull
+    @Override
+    protected SABER shallowCopy() {
+        return new SABER(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/SEED.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/SEED.java
@@ -75,4 +75,14 @@ public final class SEED extends Algorithm implements BlockCipher, KeyWrap {
     public SEED(@Nonnull final Class<? extends IPrimitive> asKind, @Nonnull SEED seed) {
         super(seed, asKind);
     }
+
+    private SEED(@Nonnull SEED sEED) {
+        super(sEED);
+    }
+
+    @Nonnull
+    @Override
+    protected SEED shallowCopy() {
+        return new SEED(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/SHA.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/SHA.java
@@ -46,4 +46,14 @@ public final class SHA extends Algorithm implements MessageDigest {
     public SHA(@Nonnull final Class<? extends IPrimitive> asKind, @Nonnull SHA sha) {
         super(sha, asKind);
     }
+
+    private SHA(@Nonnull SHA sHA) {
+        super(sHA);
+    }
+
+    @Nonnull
+    @Override
+    protected SHA shallowCopy() {
+        return new SHA(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/SHA2.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/SHA2.java
@@ -78,4 +78,14 @@ public final class SHA2 extends Algorithm implements MessageDigest {
                 .map(size -> NAME + size.asString() + "/" + digestSize)
                 .orElse(NAME + digestSize);
     }
+
+    private SHA2(@Nonnull SHA2 sHA2) {
+        super(sHA2);
+    }
+
+    @Nonnull
+    @Override
+    protected SHA2 shallowCopy() {
+        return new SHA2(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/SHA3.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/SHA3.java
@@ -75,4 +75,14 @@ public final class SHA3 extends Algorithm implements MessageDigest {
     public SHA3(@Nonnull final Class<? extends IPrimitive> asKind, @Nonnull SHA3 sha3) {
         super(sha3, asKind);
     }
+
+    private SHA3(@Nonnull SHA3 sHA3) {
+        super(sHA3);
+    }
+
+    @Nonnull
+    @Override
+    protected SHA3 shallowCopy() {
+        return new SHA3(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/SM2.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/SM2.java
@@ -56,4 +56,14 @@ public final class SM2 extends Algorithm implements Signature, PublicKeyEncrypti
     public SM2(@Nonnull final Class<? extends IPrimitive> asKind, @Nonnull SM2 sm2) {
         super(sm2, asKind);
     }
+
+    private SM2(@Nonnull SM2 sM2) {
+        super(sM2);
+    }
+
+    @Nonnull
+    @Override
+    protected SM2 shallowCopy() {
+        return new SM2(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/SM3.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/SM3.java
@@ -55,4 +55,14 @@ public final class SM3 extends Algorithm implements MessageDigest {
     public SM3(@Nonnull final Class<? extends IPrimitive> asKind, @Nonnull SM3 sm3) {
         super(sm3, asKind);
     }
+
+    private SM3(@Nonnull SM3 sM3) {
+        super(sM3);
+    }
+
+    @Nonnull
+    @Override
+    protected SM3 shallowCopy() {
+        return new SM3(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/SM4.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/SM4.java
@@ -61,4 +61,14 @@ public final class SM4 extends Algorithm implements BlockCipher, AuthenticatedEn
     public SM4(@Nonnull final Class<? extends IPrimitive> asKind, @Nonnull SM4 sm4) {
         super(sm4, asKind);
     }
+
+    private SM4(@Nonnull SM4 sM4) {
+        super(sM4);
+    }
+
+    @Nonnull
+    @Override
+    protected SM4 shallowCopy() {
+        return new SM4(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/SPHINCS.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/SPHINCS.java
@@ -64,4 +64,14 @@ public class SPHINCS extends Algorithm implements Signature {
                 new ParameterSetIdentifier(
                         String.valueOf(parameterSetIdentifier), detectionLocation));
     }
+
+    private SPHINCS(@Nonnull SPHINCS sPHINCS) {
+        super(sPHINCS);
+    }
+
+    @Nonnull
+    @Override
+    protected SPHINCS shallowCopy() {
+        return new SPHINCS(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/SPHINCSPlus.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/SPHINCSPlus.java
@@ -62,4 +62,14 @@ public class SPHINCSPlus extends Algorithm implements Signature {
         this(messageDigest.getDetectionContext());
         this.put(messageDigest);
     }
+
+    private SPHINCSPlus(@Nonnull SPHINCSPlus sPHINCSPlus) {
+        super(sPHINCSPlus);
+    }
+
+    @Nonnull
+    @Override
+    protected SPHINCSPlus shallowCopy() {
+        return new SPHINCSPlus(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/SRP.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/SRP.java
@@ -48,4 +48,14 @@ public final class SRP extends Algorithm implements KeyAgreement {
     public SRP(@Nonnull DetectionLocation detectionLocation) {
         super(NAME, KeyAgreement.class, detectionLocation);
     }
+
+    private SRP(@Nonnull SRP sRP) {
+        super(sRP);
+    }
+
+    @Nonnull
+    @Override
+    protected SRP shallowCopy() {
+        return new SRP(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/Salsa20.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/Salsa20.java
@@ -60,4 +60,14 @@ public final class Salsa20 extends Algorithm implements StreamCipher {
     public Salsa20(@Nonnull final Class<? extends IPrimitive> asKind, @Nonnull Salsa20 salsa20) {
         super(salsa20, asKind);
     }
+
+    private Salsa20(@Nonnull Salsa20 salsa20) {
+        super(salsa20);
+    }
+
+    @Nonnull
+    @Override
+    protected Salsa20 shallowCopy() {
+        return new Salsa20(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/Scrypt.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/Scrypt.java
@@ -48,4 +48,14 @@ public final class Scrypt extends Algorithm implements PasswordBasedKeyDerivatio
     public Scrypt(@Nonnull DetectionLocation detectionLocation) {
         super(NAME, PasswordBasedKeyDerivationFunction.class, detectionLocation);
     }
+
+    private Scrypt(@Nonnull Scrypt scrypt) {
+        super(scrypt);
+    }
+
+    @Nonnull
+    @Override
+    protected Scrypt shallowCopy() {
+        return new Scrypt(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/Serpent.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/Serpent.java
@@ -86,4 +86,14 @@ public final class Serpent extends Algorithm implements BlockCipher, Authenticat
     public Serpent(@Nonnull final Class<? extends IPrimitive> asKind, @Nonnull Serpent serpent) {
         super(serpent, asKind);
     }
+
+    private Serpent(@Nonnull Serpent serpent) {
+        super(serpent);
+    }
+
+    @Nonnull
+    @Override
+    protected Serpent shallowCopy() {
+        return new Serpent(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/SipHash.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/SipHash.java
@@ -57,4 +57,14 @@ public final class SipHash extends Algorithm implements Mac {
     public SipHash(@Nonnull DetectionLocation detectionLocation) {
         this(64, detectionLocation);
     }
+
+    private SipHash(@Nonnull SipHash sipHash) {
+        super(sipHash);
+    }
+
+    @Nonnull
+    @Override
+    protected SipHash shallowCopy() {
+        return new SipHash(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/Skein.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/Skein.java
@@ -73,4 +73,14 @@ public final class Skein extends Algorithm implements MessageDigest {
     public Skein(@Nonnull final Class<? extends IPrimitive> asKind, @Nonnull Skein skein) {
         super(skein, asKind);
     }
+
+    private Skein(@Nonnull Skein skein) {
+        super(skein);
+    }
+
+    @Nonnull
+    @Override
+    protected Skein shallowCopy() {
+        return new Skein(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/Skipjack.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/Skipjack.java
@@ -74,4 +74,14 @@ public final class Skipjack extends Algorithm implements BlockCipher {
     public Skipjack(@Nonnull final Class<? extends IPrimitive> asKind, @Nonnull Skipjack skipjack) {
         super(skipjack, asKind);
     }
+
+    private Skipjack(@Nonnull Skipjack skipjack) {
+        super(skipjack);
+    }
+
+    @Nonnull
+    @Override
+    protected Skipjack shallowCopy() {
+        return new Skipjack(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/Threefish.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/Threefish.java
@@ -82,4 +82,14 @@ public final class Threefish extends Algorithm implements BlockCipher, Authentic
             @Nonnull final Class<? extends IPrimitive> asKind, @Nonnull Threefish threefish) {
         super(threefish, asKind);
     }
+
+    private Threefish(@Nonnull Threefish threefish) {
+        super(threefish);
+    }
+
+    @Nonnull
+    @Override
+    protected Threefish shallowCopy() {
+        return new Threefish(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/Tiger.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/Tiger.java
@@ -60,4 +60,14 @@ public final class Tiger extends Algorithm implements MessageDigest {
         this(detectionLocation);
         this.put(new DigestSize(digestSize, detectionLocation));
     }
+
+    private Tiger(@Nonnull Tiger tiger) {
+        super(tiger);
+    }
+
+    @Nonnull
+    @Override
+    protected Tiger shallowCopy() {
+        return new Tiger(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/TripleDES.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/TripleDES.java
@@ -96,4 +96,14 @@ public final class TripleDES extends Algorithm implements BlockCipher {
             @Nonnull final Class<? extends IPrimitive> asKind, @Nonnull TripleDES tripleDES) {
         super(tripleDES, asKind);
     }
+
+    private TripleDES(@Nonnull TripleDES tripleDES) {
+        super(tripleDES);
+    }
+
+    @Nonnull
+    @Override
+    protected TripleDES shallowCopy() {
+        return new TripleDES(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/TupleHash.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/TupleHash.java
@@ -55,4 +55,14 @@ public final class TupleHash extends Algorithm implements ExtendableOutputFuncti
         this(detectionLocation);
         this.put(new DigestSize(digestSize, detectionLocation));
     }
+
+    private TupleHash(@Nonnull TupleHash tupleHash) {
+        super(tupleHash);
+    }
+
+    @Nonnull
+    @Override
+    protected TupleHash shallowCopy() {
+        return new TupleHash(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/Twofish.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/Twofish.java
@@ -84,4 +84,14 @@ public final class Twofish extends Algorithm implements BlockCipher, Authenticat
     public Twofish(@Nonnull final Class<? extends IPrimitive> asKind, @Nonnull Twofish twofish) {
         super(twofish, asKind);
     }
+
+    private Twofish(@Nonnull Twofish twofish) {
+        super(twofish);
+    }
+
+    @Nonnull
+    @Override
+    protected Twofish shallowCopy() {
+        return new Twofish(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/Whirlpool.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/Whirlpool.java
@@ -55,4 +55,14 @@ public final class Whirlpool extends Algorithm implements MessageDigest {
         this.put(BlockSize.ofDefault(512, detectionLocation));
         this.put(new NumberOfIterations(10, detectionLocation));
     }
+
+    private Whirlpool(@Nonnull Whirlpool whirlpool) {
+        super(whirlpool);
+    }
+
+    @Nonnull
+    @Override
+    protected Whirlpool shallowCopy() {
+        return new Whirlpool(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/X25519.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/X25519.java
@@ -52,4 +52,14 @@ public final class X25519 extends Algorithm implements KeyAgreement {
         this.put(new Curve25519(detectionLocation));
         this.put(new Oid("1.3.101.110", detectionLocation));
     }
+
+    private X25519(@Nonnull X25519 x25519) {
+        super(x25519);
+    }
+
+    @Nonnull
+    @Override
+    protected X25519 shallowCopy() {
+        return new X25519(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/X448.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/X448.java
@@ -52,4 +52,14 @@ public final class X448 extends Algorithm implements KeyAgreement {
         this.put(new Curve448(detectionLocation));
         this.put(new Oid("1.3.101.111", detectionLocation));
     }
+
+    private X448(@Nonnull X448 x448) {
+        super(x448);
+    }
+
+    @Nonnull
+    @Override
+    protected X448 shallowCopy() {
+        return new X448(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/XDH.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/XDH.java
@@ -48,4 +48,14 @@ public final class XDH extends Algorithm implements KeyAgreement {
     public XDH(@Nonnull DetectionLocation detectionLocation) {
         super(NAME, KeyAgreement.class, detectionLocation);
     }
+
+    private XDH(@Nonnull XDH xDH) {
+        super(xDH);
+    }
+
+    @Nonnull
+    @Override
+    protected XDH shallowCopy() {
+        return new XDH(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/XMSS.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/XMSS.java
@@ -59,4 +59,14 @@ public final class XMSS extends Algorithm implements Signature, MessageDigest {
             @Nonnull DetectionLocation detectionLocation) {
         super(NAME, asKind, detectionLocation);
     }
+
+    private XMSS(@Nonnull XMSS xMSS) {
+        super(xMSS);
+    }
+
+    @Nonnull
+    @Override
+    protected XMSS shallowCopy() {
+        return new XMSS(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/XMSSMT.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/XMSSMT.java
@@ -58,4 +58,14 @@ public final class XMSSMT extends Algorithm implements Signature, MessageDigest 
             @Nonnull DetectionLocation detectionLocation) {
         super(NAME, asKind, detectionLocation);
     }
+
+    private XMSSMT(@Nonnull XMSSMT xMSSMT) {
+        super(xMSSMT);
+    }
+
+    @Nonnull
+    @Override
+    protected XMSSMT shallowCopy() {
+        return new XMSSMT(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/Xoodyak.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/Xoodyak.java
@@ -61,4 +61,14 @@ public final class Xoodyak extends Algorithm
             @Nonnull DetectionLocation detectionLocation) {
         super(NAME, asKind, detectionLocation);
     }
+
+    private Xoodyak(@Nonnull Xoodyak xoodyak) {
+        super(xoodyak);
+    }
+
+    @Nonnull
+    @Override
+    protected Xoodyak shallowCopy() {
+        return new Xoodyak(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/ZUC.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/ZUC.java
@@ -78,4 +78,14 @@ public final class ZUC extends Algorithm implements StreamCipher, Mac {
     public ZUC(@Nonnull final Class<? extends IPrimitive> asKind, @Nonnull ZUC zuc) {
         super(zuc, asKind);
     }
+
+    private ZUC(@Nonnull ZUC zUC) {
+        super(zUC);
+    }
+
+    @Nonnull
+    @Override
+    protected ZUC shallowCopy() {
+        return new ZUC(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/ascon/Ascon.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/ascon/Ascon.java
@@ -64,4 +64,14 @@ public class Ascon extends Algorithm implements BlockCipher {
             @Nonnull DetectionLocation detectionLocation) {
         super(name, asKind, detectionLocation);
     }
+
+    protected Ascon(@Nonnull Ascon ascon) {
+        super(ascon);
+    }
+
+    @Nonnull
+    @Override
+    protected Ascon shallowCopy() {
+        return new Ascon(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/ascon/Ascon128.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/ascon/Ascon128.java
@@ -55,4 +55,14 @@ public final class Ascon128 extends Ascon implements AuthenticatedEncryption {
         this.put(new TagLength(128, detectionLocation));
         this.put(BlockSize.ofDefault(64, detectionLocation));
     }
+
+    private Ascon128(@Nonnull Ascon128 ascon128) {
+        super(ascon128);
+    }
+
+    @Nonnull
+    @Override
+    protected Ascon128 shallowCopy() {
+        return new Ascon128(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/ascon/Ascon128a.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/ascon/Ascon128a.java
@@ -55,4 +55,14 @@ public final class Ascon128a extends Ascon implements AuthenticatedEncryption {
         this.put(new TagLength(128, detectionLocation));
         this.put(BlockSize.ofDefault(128, detectionLocation));
     }
+
+    private Ascon128a(@Nonnull Ascon128a ascon128a) {
+        super(ascon128a);
+    }
+
+    @Nonnull
+    @Override
+    protected Ascon128a shallowCopy() {
+        return new Ascon128a(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/ascon/Ascon80pq.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/ascon/Ascon80pq.java
@@ -55,4 +55,14 @@ public final class Ascon80pq extends Ascon implements AuthenticatedEncryption {
         this.put(new TagLength(128, detectionLocation));
         this.put(BlockSize.ofDefault(64, detectionLocation));
     }
+
+    private Ascon80pq(@Nonnull Ascon80pq ascon80pq) {
+        super(ascon80pq);
+    }
+
+    @Nonnull
+    @Override
+    protected Ascon80pq shallowCopy() {
+        return new Ascon80pq(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/ascon/AsconHash.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/ascon/AsconHash.java
@@ -51,4 +51,14 @@ public final class AsconHash extends Ascon implements MessageDigest {
         this.put(new DigestSize(256, detectionLocation));
         this.put(BlockSize.ofDefault(64, detectionLocation));
     }
+
+    private AsconHash(@Nonnull AsconHash asconHash) {
+        super(asconHash);
+    }
+
+    @Nonnull
+    @Override
+    protected AsconHash shallowCopy() {
+        return new AsconHash(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/ascon/AsconXof.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/ascon/AsconXof.java
@@ -49,4 +49,14 @@ public final class AsconXof extends Ascon implements ExtendableOutputFunction {
         super(NAME, ExtendableOutputFunction.class, detectionLocation);
         this.put(BlockSize.ofDefault(64, detectionLocation));
     }
+
+    private AsconXof(@Nonnull AsconXof asconXof) {
+        super(asconXof);
+    }
+
+    @Nonnull
+    @Override
+    protected AsconXof shallowCopy() {
+        return new AsconXof(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/blake/BLAKE.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/blake/BLAKE.java
@@ -55,4 +55,14 @@ public final class BLAKE extends Algorithm implements MessageDigest {
     public BLAKE(@Nonnull final Class<? extends IPrimitive> asKind, @Nonnull BLAKE blake) {
         super(blake, asKind);
     }
+
+    private BLAKE(@Nonnull BLAKE bLAKE) {
+        super(bLAKE);
+    }
+
+    @Nonnull
+    @Override
+    protected BLAKE shallowCopy() {
+        return new BLAKE(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/blake/BLAKE2X.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/blake/BLAKE2X.java
@@ -51,4 +51,14 @@ public final class BLAKE2X extends Algorithm implements ExtendableOutputFunction
         super(NAME, ExtendableOutputFunction.class, detectionLocation);
         this.put(blake2);
     }
+
+    private BLAKE2X(@Nonnull BLAKE2X bLAKE2X) {
+        super(bLAKE2X);
+    }
+
+    @Nonnull
+    @Override
+    protected BLAKE2X shallowCopy() {
+        return new BLAKE2X(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/blake/BLAKE2b.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/blake/BLAKE2b.java
@@ -67,4 +67,14 @@ public final class BLAKE2b extends Algorithm implements MessageDigest {
     public BLAKE2b(@Nonnull final Class<? extends IPrimitive> asKind, @Nonnull BLAKE2b blake) {
         super(blake, asKind);
     }
+
+    private BLAKE2b(@Nonnull BLAKE2b bLAKE2b) {
+        super(bLAKE2b);
+    }
+
+    @Nonnull
+    @Override
+    protected BLAKE2b shallowCopy() {
+        return new BLAKE2b(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/blake/BLAKE2s.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/blake/BLAKE2s.java
@@ -67,4 +67,14 @@ public final class BLAKE2s extends Algorithm implements MessageDigest {
     public BLAKE2s(@Nonnull final Class<? extends IPrimitive> asKind, @Nonnull BLAKE2s blake) {
         super(blake, asKind);
     }
+
+    private BLAKE2s(@Nonnull BLAKE2s bLAKE2s) {
+        super(bLAKE2s);
+    }
+
+    @Nonnull
+    @Override
+    protected BLAKE2s shallowCopy() {
+        return new BLAKE2s(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/blake/BLAKE3.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/blake/BLAKE3.java
@@ -62,4 +62,14 @@ public final class BLAKE3 extends Algorithm implements MessageDigest, KeyDerivat
     public BLAKE3(@Nonnull final Class<? extends IPrimitive> asKind, @Nonnull BLAKE3 blake) {
         super(blake, asKind);
     }
+
+    private BLAKE3(@Nonnull BLAKE3 bLAKE3) {
+        super(bLAKE3);
+    }
+
+    @Nonnull
+    @Override
+    protected BLAKE3 shallowCopy() {
+        return new BLAKE3(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/cast/CAST128.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/cast/CAST128.java
@@ -85,4 +85,14 @@ public final class CAST128 extends Algorithm implements BlockCipher {
     public CAST128(@Nonnull final Class<? extends IPrimitive> asKind, @Nonnull CAST128 cast128) {
         super(cast128, asKind);
     }
+
+    private CAST128(@Nonnull CAST128 cAST128) {
+        super(cAST128);
+    }
+
+    @Nonnull
+    @Override
+    protected CAST128 shallowCopy() {
+        return new CAST128(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/cast/CAST256.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/cast/CAST256.java
@@ -85,4 +85,14 @@ public final class CAST256 extends Algorithm implements BlockCipher {
     public CAST256(@Nonnull final Class<? extends IPrimitive> asKind, @Nonnull CAST256 cast256) {
         super(cast256, asKind);
     }
+
+    private CAST256(@Nonnull CAST256 cAST256) {
+        super(cAST256);
+    }
+
+    @Nonnull
+    @Override
+    protected CAST256 shallowCopy() {
+        return new CAST256(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/elephant/Delirium.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/elephant/Delirium.java
@@ -50,4 +50,14 @@ public class Delirium extends Elephant {
         this.put(BlockSize.ofDefault(200, detectionLocation));
         this.put(new TagLength(128, detectionLocation));
     }
+
+    private Delirium(@Nonnull Delirium delirium) {
+        super(delirium);
+    }
+
+    @Nonnull
+    @Override
+    protected Delirium shallowCopy() {
+        return new Delirium(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/elephant/Dumbo.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/elephant/Dumbo.java
@@ -50,4 +50,14 @@ public class Dumbo extends Elephant {
         this.put(BlockSize.ofDefault(160, detectionLocation));
         this.put(new TagLength(64, detectionLocation));
     }
+
+    private Dumbo(@Nonnull Dumbo dumbo) {
+        super(dumbo);
+    }
+
+    @Nonnull
+    @Override
+    protected Dumbo shallowCopy() {
+        return new Dumbo(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/elephant/Elephant.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/elephant/Elephant.java
@@ -57,4 +57,14 @@ public class Elephant extends Algorithm implements AuthenticatedEncryption {
         this.put(KeyLength.ofDefault(128, detectionLocation));
         this.put(new NonceLength(96, detectionLocation));
     }
+
+    protected Elephant(@Nonnull Elephant elephant) {
+        super(elephant);
+    }
+
+    @Nonnull
+    @Override
+    protected Elephant shallowCopy() {
+        return new Elephant(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/elephant/Jumbo.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/elephant/Jumbo.java
@@ -50,4 +50,14 @@ public class Jumbo extends Elephant {
         this.put(BlockSize.ofDefault(176, detectionLocation));
         this.put(new TagLength(64, detectionLocation));
     }
+
+    private Jumbo(@Nonnull Jumbo jumbo) {
+        super(jumbo);
+    }
+
+    @Nonnull
+    @Override
+    protected Jumbo shallowCopy() {
+        return new Jumbo(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/gost/CryptoPro.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/gost/CryptoPro.java
@@ -49,4 +49,14 @@ public class CryptoPro extends Algorithm implements KeyWrap {
     public CryptoPro(@Nonnull DetectionLocation detectionLocation) {
         super(NAME, KeyWrap.class, detectionLocation);
     }
+
+    private CryptoPro(@Nonnull CryptoPro cryptoPro) {
+        super(cryptoPro);
+    }
+
+    @Nonnull
+    @Override
+    protected CryptoPro shallowCopy() {
+        return new CryptoPro(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/gost/GOST28147.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/gost/GOST28147.java
@@ -72,4 +72,14 @@ public final class GOST28147 extends Algorithm
             @Nonnull final Class<? extends IPrimitive> asKind, @Nonnull GOST28147 gost28147) {
         super(gost28147, asKind);
     }
+
+    private GOST28147(@Nonnull GOST28147 gOST28147) {
+        super(gOST28147);
+    }
+
+    @Nonnull
+    @Override
+    protected GOST28147 shallowCopy() {
+        return new GOST28147(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/gost/GOST341194.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/gost/GOST341194.java
@@ -63,4 +63,14 @@ public final class GOST341194 extends Algorithm implements MessageDigest {
             @Nonnull final Class<? extends MessageDigest> asKind, @Nonnull GOST341194 gostr341194) {
         super(gostr341194, asKind);
     }
+
+    private GOST341194(@Nonnull GOST341194 gOST341194) {
+        super(gOST341194);
+    }
+
+    @Nonnull
+    @Override
+    protected GOST341194 shallowCopy() {
+        return new GOST341194(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/gost/GOSTR341012.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/gost/GOSTR341012.java
@@ -48,4 +48,14 @@ public final class GOSTR341012 extends Algorithm implements Signature {
     public GOSTR341012(@Nonnull DetectionLocation detectionLocation) {
         super(NAME, Signature.class, detectionLocation);
     }
+
+    private GOSTR341012(@Nonnull GOSTR341012 gOSTR341012) {
+        super(gOSTR341012);
+    }
+
+    @Nonnull
+    @Override
+    protected GOSTR341012 shallowCopy() {
+        return new GOSTR341012(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/gost/GOSTR341094.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/gost/GOSTR341094.java
@@ -48,4 +48,14 @@ public final class GOSTR341094 extends Algorithm implements Signature {
     public GOSTR341094(@Nonnull DetectionLocation detectionLocation) {
         super(NAME, Signature.class, detectionLocation);
     }
+
+    private GOSTR341094(@Nonnull GOSTR341094 gOSTR341094) {
+        super(gOSTR341094);
+    }
+
+    @Nonnull
+    @Override
+    protected GOSTR341094 shallowCopy() {
+        return new GOSTR341094(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/gost/GOSTR341112.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/gost/GOSTR341112.java
@@ -63,4 +63,14 @@ public final class GOSTR341112 extends Algorithm implements MessageDigest {
             @Nonnull GOSTR341112 gostr341112) {
         super(gostr341112, asKind);
     }
+
+    private GOSTR341112(@Nonnull GOSTR341112 gOSTR341112) {
+        super(gOSTR341112);
+    }
+
+    @Nonnull
+    @Override
+    protected GOSTR341112 shallowCopy() {
+        return new GOSTR341112(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/gost/GOSTR34122015.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/gost/GOSTR34122015.java
@@ -66,4 +66,14 @@ public final class GOSTR34122015 extends Algorithm implements BlockCipher, Authe
             @Nonnull GOSTR34122015 gostr34122015) {
         super(gostr34122015, asKind);
     }
+
+    private GOSTR34122015(@Nonnull GOSTR34122015 gOSTR34122015) {
+        super(gOSTR34122015);
+    }
+
+    @Nonnull
+    @Override
+    protected GOSTR34122015 shallowCopy() {
+        return new GOSTR34122015(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/grain/Grain.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/grain/Grain.java
@@ -38,4 +38,14 @@ public class Grain extends Algorithm implements StreamCipher {
             @Nonnull DetectionLocation detectionLocation) {
         super(name, asKind, detectionLocation);
     }
+
+    protected Grain(@Nonnull Grain grain) {
+        super(grain);
+    }
+
+    @Nonnull
+    @Override
+    protected Grain shallowCopy() {
+        return new Grain(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/grain/Grain128.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/grain/Grain128.java
@@ -33,4 +33,14 @@ public class Grain128 extends Grain {
         this.put(KeyLength.ofDefault(128, detectionLocation));
         this.put(new InitializationVectorLength(96, detectionLocation));
     }
+
+    private Grain128(@Nonnull Grain128 grain128) {
+        super(grain128);
+    }
+
+    @Nonnull
+    @Override
+    protected Grain128 shallowCopy() {
+        return new Grain128(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/grain/Grain128AEAD.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/grain/Grain128AEAD.java
@@ -52,4 +52,14 @@ public class Grain128AEAD extends Grain implements AuthenticatedEncryption {
         this.put(KeyLength.ofDefault(128, detectionLocation));
         this.put(new InitializationVectorLength(96, detectionLocation));
     }
+
+    private Grain128AEAD(@Nonnull Grain128AEAD grain128AEAD) {
+        super(grain128AEAD);
+    }
+
+    @Nonnull
+    @Override
+    protected Grain128AEAD shallowCopy() {
+        return new Grain128AEAD(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/grain/Grain128AEADv2.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/grain/Grain128AEADv2.java
@@ -52,4 +52,14 @@ public class Grain128AEADv2 extends Grain implements AuthenticatedEncryption {
         this.put(KeyLength.ofDefault(128, detectionLocation));
         this.put(new InitializationVectorLength(96, detectionLocation));
     }
+
+    private Grain128AEADv2(@Nonnull Grain128AEADv2 grain128AEADv2) {
+        super(grain128AEADv2);
+    }
+
+    @Nonnull
+    @Override
+    protected Grain128AEADv2 shallowCopy() {
+        return new Grain128AEADv2(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/grain/Grain128a.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/grain/Grain128a.java
@@ -33,4 +33,14 @@ public class Grain128a extends Grain {
         this.put(KeyLength.ofDefault(128, detectionLocation));
         this.put(new InitializationVectorLength(96, detectionLocation));
     }
+
+    private Grain128a(@Nonnull Grain128a grain128a) {
+        super(grain128a);
+    }
+
+    @Nonnull
+    @Override
+    protected Grain128a shallowCopy() {
+        return new Grain128a(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/grain/Grainv0.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/grain/Grainv0.java
@@ -52,4 +52,14 @@ public class Grainv0 extends Grain {
         this.put(KeyLength.ofDefault(80, detectionLocation));
         this.put(new InitializationVectorLength(64, detectionLocation));
     }
+
+    private Grainv0(@Nonnull Grainv0 grainv0) {
+        super(grainv0);
+    }
+
+    @Nonnull
+    @Override
+    protected Grainv0 shallowCopy() {
+        return new Grainv0(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/grain/Grainv1.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/grain/Grainv1.java
@@ -33,4 +33,14 @@ public class Grainv1 extends Grain {
         this.put(KeyLength.ofDefault(80, detectionLocation));
         this.put(new InitializationVectorLength(64, detectionLocation));
     }
+
+    private Grainv1(@Nonnull Grainv1 grainv1) {
+        super(grainv1);
+    }
+
+    @Nonnull
+    @Override
+    protected Grainv1 shallowCopy() {
+        return new Grainv1(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/ies/DLIES.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/ies/DLIES.java
@@ -50,4 +50,14 @@ public class DLIES extends IES {
         super(NAME, PublicKeyEncryption.class, detectionLocation);
         this.put(new DH(detectionLocation));
     }
+
+    private DLIES(@Nonnull DLIES dLIES) {
+        super(dLIES);
+    }
+
+    @Nonnull
+    @Override
+    protected DLIES shallowCopy() {
+        return new DLIES(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/ies/ECIES.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/ies/ECIES.java
@@ -50,4 +50,14 @@ public class ECIES extends IES {
         super(NAME, PublicKeyEncryption.class, detectionLocation);
         this.put(new DH(detectionLocation));
     }
+
+    private ECIES(@Nonnull ECIES eCIES) {
+        super(eCIES);
+    }
+
+    @Nonnull
+    @Override
+    protected ECIES shallowCopy() {
+        return new ECIES(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/ies/ECIESKEM.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/ies/ECIESKEM.java
@@ -50,4 +50,14 @@ public class ECIESKEM extends Algorithm implements KeyEncapsulationMechanism {
     public ECIESKEM(@Nonnull DetectionLocation detectionLocation) {
         super(NAME, KeyEncapsulationMechanism.class, detectionLocation);
     }
+
+    private ECIESKEM(@Nonnull ECIESKEM eCIESKEM) {
+        super(eCIESKEM);
+    }
+
+    @Nonnull
+    @Override
+    protected ECIESKEM shallowCopy() {
+        return new ECIESKEM(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/ies/IES.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/ies/IES.java
@@ -62,4 +62,14 @@ public class IES extends Algorithm implements PublicKeyEncryption, KeyEncapsulat
     public IES(@Nonnull final Class<? extends IPrimitive> asKind, @Nonnull IES ies) {
         super(ies, asKind);
     }
+
+    protected IES(@Nonnull IES iES) {
+        super(iES);
+    }
+
+    @Nonnull
+    @Override
+    protected IES shallowCopy() {
+        return new IES(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/isap/Isap.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/isap/Isap.java
@@ -64,4 +64,14 @@ public class Isap extends Algorithm implements AuthenticatedEncryption {
         this.put(new NonceLength(128, detectionLocation));
         this.put(new TagLength(128, detectionLocation));
     }
+
+    protected Isap(@Nonnull Isap isap) {
+        super(isap);
+    }
+
+    @Nonnull
+    @Override
+    protected Isap shallowCopy() {
+        return new Isap(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/isap/IsapA128.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/isap/IsapA128.java
@@ -32,4 +32,14 @@ public class IsapA128 extends Isap {
         this.put(BlockSize.ofDefault(64, detectionLocation));
         this.put(new InitializationVectorLength(192, detectionLocation));
     }
+
+    private IsapA128(@Nonnull IsapA128 isapA128) {
+        super(isapA128);
+    }
+
+    @Nonnull
+    @Override
+    protected IsapA128 shallowCopy() {
+        return new IsapA128(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/isap/IsapA128a.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/isap/IsapA128a.java
@@ -32,4 +32,14 @@ public class IsapA128a extends Isap {
         this.put(BlockSize.ofDefault(64, detectionLocation));
         this.put(new InitializationVectorLength(192, detectionLocation));
     }
+
+    private IsapA128a(@Nonnull IsapA128a isapA128a) {
+        super(isapA128a);
+    }
+
+    @Nonnull
+    @Override
+    protected IsapA128a shallowCopy() {
+        return new IsapA128a(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/isap/IsapK128.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/isap/IsapK128.java
@@ -32,4 +32,14 @@ public class IsapK128 extends Isap {
         this.put(BlockSize.ofDefault(144, detectionLocation));
         this.put(new InitializationVectorLength(272, detectionLocation));
     }
+
+    private IsapK128(@Nonnull IsapK128 isapK128) {
+        super(isapK128);
+    }
+
+    @Nonnull
+    @Override
+    protected IsapK128 shallowCopy() {
+        return new IsapK128(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/isap/IsapK128a.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/isap/IsapK128a.java
@@ -32,4 +32,14 @@ public class IsapK128a extends Isap {
         this.put(BlockSize.ofDefault(144, detectionLocation));
         this.put(new InitializationVectorLength(272, detectionLocation));
     }
+
+    private IsapK128a(@Nonnull IsapK128a isapK128a) {
+        super(isapK128a);
+    }
+
+    @Nonnull
+    @Override
+    protected IsapK128a shallowCopy() {
+        return new IsapK128a(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/kyber/Kyber.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/kyber/Kyber.java
@@ -94,4 +94,14 @@ public class Kyber extends Algorithm implements KeyEncapsulationMechanism {
         this(parameterSetIdentifier, detectionLocation);
         this.put(new Version(submissionVersionNumber, detectionLocation));
     }
+
+    private Kyber(@Nonnull Kyber kyber) {
+        super(kyber);
+    }
+
+    @Nonnull
+    @Override
+    protected Kyber shallowCopy() {
+        return new Kyber(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/ntru/NTRU.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/ntru/NTRU.java
@@ -50,4 +50,14 @@ public class NTRU extends Algorithm implements KeyEncapsulationMechanism {
     public NTRU(@Nonnull DetectionLocation detectionLocation) {
         super(NAME, KeyEncapsulationMechanism.class, detectionLocation);
     }
+
+    private NTRU(@Nonnull NTRU nTRU) {
+        super(nTRU);
+    }
+
+    @Nonnull
+    @Override
+    protected NTRU shallowCopy() {
+        return new NTRU(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/ntru/NTRUEncrypt.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/ntru/NTRUEncrypt.java
@@ -61,4 +61,14 @@ public final class NTRUEncrypt extends Algorithm implements PublicKeyEncryption 
             @Nonnull final Class<? extends IPrimitive> asKind, @Nonnull NTRUEncrypt ntruEncrypt) {
         super(ntruEncrypt, asKind);
     }
+
+    private NTRUEncrypt(@Nonnull NTRUEncrypt nTRUEncrypt) {
+        super(nTRUEncrypt);
+    }
+
+    @Nonnull
+    @Override
+    protected NTRUEncrypt shallowCopy() {
+        return new NTRUEncrypt(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/ntru/NTRULPrime.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/ntru/NTRULPrime.java
@@ -49,4 +49,14 @@ public class NTRULPrime extends Algorithm implements KeyEncapsulationMechanism {
     public NTRULPrime(@Nonnull DetectionLocation detectionLocation) {
         super(NAME, KeyEncapsulationMechanism.class, detectionLocation);
     }
+
+    private NTRULPrime(@Nonnull NTRULPrime nTRULPrime) {
+        super(nTRULPrime);
+    }
+
+    @Nonnull
+    @Override
+    protected NTRULPrime shallowCopy() {
+        return new NTRULPrime(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/ntru/NTRUSign.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/ntru/NTRUSign.java
@@ -30,4 +30,14 @@ public class NTRUSign extends Algorithm implements Signature {
     public NTRUSign(@Nonnull DetectionLocation detectionLocation) {
         super(NAME, Signature.class, detectionLocation);
     }
+
+    private NTRUSign(@Nonnull NTRUSign nTRUSign) {
+        super(nTRUSign);
+    }
+
+    @Nonnull
+    @Override
+    protected NTRUSign shallowCopy() {
+        return new NTRUSign(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/ntru/StreamlinedNTRUPrime.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/ntru/StreamlinedNTRUPrime.java
@@ -49,4 +49,14 @@ public class StreamlinedNTRUPrime extends Algorithm implements KeyEncapsulationM
     public StreamlinedNTRUPrime(@Nonnull DetectionLocation detectionLocation) {
         super(NAME, KeyEncapsulationMechanism.class, detectionLocation);
     }
+
+    private StreamlinedNTRUPrime(@Nonnull StreamlinedNTRUPrime streamlinedNTRUPrime) {
+        super(streamlinedNTRUPrime);
+    }
+
+    @Nonnull
+    @Override
+    protected StreamlinedNTRUPrime shallowCopy() {
+        return new StreamlinedNTRUPrime(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/photonbeetle/PhotonBeetleAEAD.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/photonbeetle/PhotonBeetleAEAD.java
@@ -61,4 +61,14 @@ public class PhotonBeetleAEAD extends Algorithm implements AuthenticatedEncrypti
         this(detectionLocation);
         this.put(new BlockSize(rate, detectionLocation));
     }
+
+    private PhotonBeetleAEAD(@Nonnull PhotonBeetleAEAD photonBeetleAEAD) {
+        super(photonBeetleAEAD);
+    }
+
+    @Nonnull
+    @Override
+    protected PhotonBeetleAEAD shallowCopy() {
+        return new PhotonBeetleAEAD(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/photonbeetle/PhotonBeetleHash.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/photonbeetle/PhotonBeetleHash.java
@@ -57,4 +57,14 @@ public class PhotonBeetleHash extends Algorithm implements MessageDigest {
         this(detectionLocation);
         this.put(new BlockSize(blockSize, detectionLocation));
     }
+
+    private PhotonBeetleHash(@Nonnull PhotonBeetleHash photonBeetleHash) {
+        super(photonBeetleHash);
+    }
+
+    @Nonnull
+    @Override
+    protected PhotonBeetleHash shallowCopy() {
+        return new PhotonBeetleHash(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/shacal/SHACAL1.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/shacal/SHACAL1.java
@@ -84,4 +84,14 @@ public final class SHACAL1 extends Algorithm implements BlockCipher, Authenticat
     public SHACAL1(@Nonnull final Class<? extends IPrimitive> asKind, @Nonnull SHACAL2 shacal1) {
         super(shacal1, asKind);
     }
+
+    private SHACAL1(@Nonnull SHACAL1 sHACAL1) {
+        super(sHACAL1);
+    }
+
+    @Nonnull
+    @Override
+    protected SHACAL1 shallowCopy() {
+        return new SHACAL1(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/shacal/SHACAL2.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/shacal/SHACAL2.java
@@ -83,4 +83,14 @@ public final class SHACAL2 extends Algorithm implements BlockCipher, Authenticat
     public SHACAL2(@Nonnull final Class<? extends IPrimitive> asKind, @Nonnull SHACAL2 shacal2) {
         super(shacal2, asKind);
     }
+
+    private SHACAL2(@Nonnull SHACAL2 sHACAL2) {
+        super(sHACAL2);
+    }
+
+    @Nonnull
+    @Override
+    protected SHACAL2 shallowCopy() {
+        return new SHACAL2(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/shake/CSHAKE.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/shake/CSHAKE.java
@@ -76,4 +76,14 @@ public final class CSHAKE extends Algorithm implements ExtendableOutputFunction 
     public CSHAKE(@Nonnull final Class<? extends IPrimitive> asKind, @Nonnull CSHAKE cSHAKE) {
         super(cSHAKE, asKind);
     }
+
+    private CSHAKE(@Nonnull CSHAKE cSHAKE) {
+        super(cSHAKE);
+    }
+
+    @Nonnull
+    @Override
+    protected CSHAKE shallowCopy() {
+        return new CSHAKE(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/shake/SHAKE.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/shake/SHAKE.java
@@ -79,4 +79,14 @@ public final class SHAKE extends Algorithm implements ExtendableOutputFunction {
     public SHAKE(@Nonnull final Class<? extends IPrimitive> asKind, @Nonnull SHAKE shake) {
         super(shake, asKind);
     }
+
+    private SHAKE(@Nonnull SHAKE sHAKE) {
+        super(sHAKE);
+    }
+
+    @Nonnull
+    @Override
+    protected SHAKE shallowCopy() {
+        return new SHAKE(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/sparkle/Esch.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/sparkle/Esch.java
@@ -81,4 +81,14 @@ public final class Esch extends Algorithm implements MessageDigest {
             this.put(new ClassicalBitSecurityLevel(192, detectionLocation));
         }
     }
+
+    private Esch(@Nonnull Esch esch) {
+        super(esch);
+    }
+
+    @Nonnull
+    @Override
+    protected Esch shallowCopy() {
+        return new Esch(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/sparkle/Schwaemm.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/sparkle/Schwaemm.java
@@ -89,4 +89,14 @@ public class Schwaemm extends Algorithm implements AuthenticatedEncryption, Bloc
         this.put(new TagLength(capacity, detectionLocation));
         this.put(new NonceLength(rate, detectionLocation));
     }
+
+    private Schwaemm(@Nonnull Schwaemm schwaemm) {
+        super(schwaemm);
+    }
+
+    @Nonnull
+    @Override
+    protected Schwaemm shallowCopy() {
+        return new Schwaemm(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/sparkle/XOEsch.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/sparkle/XOEsch.java
@@ -52,4 +52,14 @@ public final class XOEsch extends Algorithm implements MessageDigest {
         super(NAME, MessageDigest.class, detectionLocation);
         this.put(BlockSize.ofDefault(128, detectionLocation));
     }
+
+    private XOEsch(@Nonnull XOEsch xOEsch) {
+        super(xOEsch);
+    }
+
+    @Nonnull
+    @Override
+    protected XOEsch shallowCopy() {
+        return new XOEsch(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/tea/TEA.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/tea/TEA.java
@@ -75,4 +75,14 @@ public final class TEA extends Algorithm implements BlockCipher {
     public TEA(@Nonnull final Class<? extends IPrimitive> asKind, @Nonnull TEA tea) {
         super(tea, asKind);
     }
+
+    private TEA(@Nonnull TEA tEA) {
+        super(tEA);
+    }
+
+    @Nonnull
+    @Override
+    protected TEA shallowCopy() {
+        return new TEA(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/tea/XTEA.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/tea/XTEA.java
@@ -76,4 +76,14 @@ public final class XTEA extends Algorithm implements BlockCipher {
     public XTEA(@Nonnull final Class<? extends IPrimitive> asKind, @Nonnull XTEA xtea) {
         super(xtea, asKind);
     }
+
+    private XTEA(@Nonnull XTEA xTEA) {
+        super(xTEA);
+    }
+
+    @Nonnull
+    @Override
+    protected XTEA shallowCopy() {
+        return new XTEA(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/vmpc/VMPC.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/vmpc/VMPC.java
@@ -50,4 +50,14 @@ public class VMPC extends Algorithm implements StreamCipher {
     public VMPC(@Nonnull DetectionLocation detectionLocation) {
         super(NAME, StreamCipher.class, detectionLocation);
     }
+
+    private VMPC(@Nonnull VMPC vMPC) {
+        super(vMPC);
+    }
+
+    @Nonnull
+    @Override
+    protected VMPC shallowCopy() {
+        return new VMPC(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/vmpc/VMPCKSA.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/vmpc/VMPCKSA.java
@@ -64,4 +64,14 @@ public class VMPCKSA extends Algorithm implements StreamCipher {
         this(detectionLocation);
         this.put(new Version(String.valueOf(version), detectionLocation));
     }
+
+    private VMPCKSA(@Nonnull VMPCKSA vMPCKSA) {
+        super(vMPCKSA);
+    }
+
+    @Nonnull
+    @Override
+    protected VMPCKSA shallowCopy() {
+        return new VMPCKSA(this);
+    }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/algorithms/vmpc/VMPCMAC.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/algorithms/vmpc/VMPCMAC.java
@@ -50,4 +50,14 @@ public final class VMPCMAC extends Algorithm implements Mac {
         super(NAME, Mac.class, detectionLocation);
         this.put(new VMPC(detectionLocation));
     }
+
+    private VMPCMAC(@Nonnull VMPCMAC vMPCMAC) {
+        super(vMPCMAC);
+    }
+
+    @Nonnull
+    @Override
+    protected VMPCMAC shallowCopy() {
+        return new VMPCMAC(this);
+    }
 }

--- a/mapper/src/test/java/com/ibm/mapper/model/AlgorithmDeepCopyTest.java
+++ b/mapper/src/test/java/com/ibm/mapper/model/AlgorithmDeepCopyTest.java
@@ -1,0 +1,247 @@
+/*
+ * Sonar Cryptography Plugin
+ * Copyright (C) 2026 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.mapper.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ibm.mapper.model.algorithms.AES;
+import com.ibm.mapper.model.algorithms.RSA;
+import com.ibm.mapper.model.algorithms.SHA2;
+import com.ibm.mapper.model.algorithms.ascon.Ascon128;
+import com.ibm.mapper.model.mode.CBC;
+import com.ibm.mapper.model.padding.PKCS5;
+import com.ibm.mapper.utils.DetectionLocation;
+import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Modifier;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+import javax.annotation.Nonnull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class AlgorithmDeepCopyTest {
+
+    private static final DetectionLocation DETECTION_LOCATION =
+            new DetectionLocation("testfile", 1, 1, List.of("test"), () -> "SSL");
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("directAlgorithmSubclasses")
+    void directAlgorithmSubclassesMustDeepCopyToTheirConcreteType(
+            Class<? extends Algorithm> algorithmClass) {
+        Algorithm algorithm = instantiate(algorithmClass);
+
+        INode copy = algorithm.deepCopy();
+
+        assertThat(copy.getClass())
+                .as("%s.deepCopy() must preserve concrete type", algorithmClass.getName())
+                .isEqualTo(algorithmClass);
+    }
+
+    @Test
+    void deepCopyPreservesDirectAlgorithmSubclass() {
+        AES aes =
+                new AES(
+                        128,
+                        new CBC(DETECTION_LOCATION),
+                        new PKCS5(DETECTION_LOCATION),
+                        DETECTION_LOCATION);
+
+        INode copy = aes.deepCopy();
+
+        assertThat(copy).isInstanceOf(AES.class).isNotSameAs(aes);
+        assertThat(copy.hasChildOfType(KeyLength.class)).isPresent();
+        assertThat(copy.hasChildOfType(KeyLength.class).get())
+                .isNotSameAs(aes.hasChildOfType(KeyLength.class).get());
+
+        // Verify metadata is preserved
+        AES aesCopy = (AES) copy;
+        assertThat(aesCopy.getName()).isEqualTo(aes.getName());
+        assertThat(aesCopy.getKind()).isEqualTo(aes.getKind());
+        assertThat(aesCopy.getDetectionContext()).isEqualTo(aes.getDetectionContext());
+        assertThat(aesCopy.getOrigin()).isEqualTo(aes.getOrigin());
+    }
+
+    @Test
+    void deepCopyPreservesExistingSpecializedSubclass() {
+        RSA rsa = new RSA(2048, DETECTION_LOCATION);
+
+        INode copy = rsa.deepCopy();
+
+        assertThat(copy).isInstanceOf(RSA.class).isNotSameAs(rsa);
+        assertThat(copy.hasChildOfType(KeyLength.class)).isPresent();
+        // Verify the recursive child.deepCopy() loop ran — child must be a distinct object
+        assertThat(copy.hasChildOfType(KeyLength.class).get())
+                .isNotSameAs(rsa.hasChildOfType(KeyLength.class).get());
+
+        // Verify metadata is preserved (especially origin, which the old custom path could drop)
+        RSA rsaCopy = (RSA) copy;
+        assertThat(rsaCopy.getName()).isEqualTo(rsa.getName());
+        assertThat(rsaCopy.getKind()).isEqualTo(rsa.getKind());
+        assertThat(rsaCopy.getDetectionContext()).isEqualTo(rsa.getDetectionContext());
+        assertThat(rsaCopy.getOrigin()).isEqualTo(rsa.getOrigin());
+    }
+
+    @Test
+    void deepCopyPreservesIndirectAlgorithmSubclass() {
+        Ascon128 ascon128 = new Ascon128(DETECTION_LOCATION);
+
+        INode copy = ascon128.deepCopy();
+
+        assertThat(copy).isInstanceOf(Ascon128.class).isNotSameAs(ascon128);
+        assertThat(copy.hasChildOfType(TagLength.class)).isPresent();
+        // Verify the recursive child.deepCopy() loop ran — child must be a distinct object
+        assertThat(copy.hasChildOfType(TagLength.class).get())
+                .isNotSameAs(ascon128.hasChildOfType(TagLength.class).get());
+
+        // Verify metadata is preserved
+        Ascon128 asconCopy = (Ascon128) copy;
+        assertThat(asconCopy.getName()).isEqualTo(ascon128.getName());
+        assertThat(asconCopy.getKind()).isEqualTo(ascon128.getKind());
+        assertThat(asconCopy.getDetectionContext()).isEqualTo(ascon128.getDetectionContext());
+        assertThat(asconCopy.getOrigin()).isEqualTo(ascon128.getOrigin());
+    }
+
+    private static Stream<Class<? extends Algorithm>> directAlgorithmSubclasses()
+            throws IOException, URISyntaxException, ClassNotFoundException {
+        return algorithmClassesIn("com.ibm.mapper.model.algorithms")
+                .filter(algorithmClass -> algorithmClass.getSuperclass().equals(Algorithm.class))
+                .filter(algorithmClass -> !Modifier.isAbstract(algorithmClass.getModifiers()))
+                .sorted(Comparator.comparing(Class::getName));
+    }
+
+    private static Stream<Class<? extends Algorithm>> algorithmClassesIn(
+            @Nonnull String packageName)
+            throws IOException, URISyntaxException, ClassNotFoundException {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        String packagePath = packageName.replace('.', '/');
+        Enumeration<URL> resources = classLoader.getResources(packagePath);
+
+        Stream.Builder<Class<? extends Algorithm>> classes = Stream.builder();
+        while (resources.hasMoreElements()) {
+            URL resource = resources.nextElement();
+            if ("file".equals(resource.getProtocol())) {
+                try (Stream<Path> paths = Files.walk(Path.of(resource.toURI()))) {
+                    for (Path classFile :
+                            paths.filter(path -> path.toString().endsWith(".class")).toList()) {
+                        String className =
+                                toClassName(packageName, Path.of(resource.toURI()), classFile);
+                        Class<?> loadedClass = Class.forName(className);
+                        if (Algorithm.class.isAssignableFrom(loadedClass)
+                                && !loadedClass.getName().contains("$")) {
+                            classes.add(loadedClass.asSubclass(Algorithm.class));
+                        }
+                    }
+                }
+            }
+        }
+        return classes.build();
+    }
+
+    private static String toClassName(
+            @Nonnull String packageName, @Nonnull Path packageRoot, @Nonnull Path classFile) {
+        String relativeClassName =
+                packageRoot
+                        .relativize(classFile)
+                        .toString()
+                        .replace('\\', '.')
+                        .replace('/', '.')
+                        .replaceAll("\\.class$", "");
+        return packageName + "." + relativeClassName;
+    }
+
+    private static Algorithm instantiate(@Nonnull Class<? extends Algorithm> algorithmClass) {
+        return Arrays.stream(algorithmClass.getDeclaredConstructors())
+                .filter(constructor -> !isCopyConstructor(algorithmClass, constructor))
+                .sorted(Comparator.comparingInt(Constructor::getParameterCount))
+                .map(constructor -> instantiate(algorithmClass, constructor))
+                .flatMap(Optional::stream)
+                .findFirst()
+                .orElseThrow(
+                        () ->
+                                new AssertionError(
+                                        "No supported constructor found for "
+                                                + algorithmClass.getName()));
+    }
+
+    private static boolean isCopyConstructor(
+            @Nonnull Class<? extends Algorithm> algorithmClass,
+            @Nonnull Constructor<?> constructor) {
+        return constructor.getParameterCount() == 1
+                && constructor.getParameterTypes()[0].equals(algorithmClass);
+    }
+
+    private static Optional<Algorithm> instantiate(
+            @Nonnull Class<? extends Algorithm> algorithmClass,
+            @Nonnull Constructor<?> constructor) {
+        Optional<Object[]> arguments = argumentsFor(constructor.getParameterTypes());
+        if (arguments.isEmpty()) {
+            return Optional.empty();
+        }
+        try {
+            constructor.setAccessible(true);
+            return Optional.of((Algorithm) constructor.newInstance(arguments.get()));
+        } catch (InstantiationException
+                | IllegalAccessException
+                | InvocationTargetException
+                | IllegalArgumentException exception) {
+            throw new AssertionError(
+                    "Could not instantiate " + algorithmClass.getName() + " using " + constructor,
+                    exception);
+        }
+    }
+
+    private static Optional<Object[]> argumentsFor(@Nonnull Class<?>[] parameterTypes) {
+        Object[] arguments = new Object[parameterTypes.length];
+        for (int i = 0; i < parameterTypes.length; i++) {
+            Optional<Object> argument = argumentFor(parameterTypes[i]);
+            if (argument.isEmpty()) {
+                return Optional.empty();
+            }
+            arguments[i] = argument.get();
+        }
+        return Optional.of(arguments);
+    }
+
+    private static Optional<Object> argumentFor(@Nonnull Class<?> parameterType) {
+        if (parameterType.equals(DetectionLocation.class)) {
+            return Optional.of(DETECTION_LOCATION);
+        } else if (parameterType.equals(int.class) || parameterType.equals(Integer.class)) {
+            return Optional.of(128);
+        } else if (parameterType.equals(String.class)) {
+            return Optional.of("test");
+        } else if (parameterType.equals(Class.class)) {
+            return Optional.of(IPrimitive.class);
+        } else if (parameterType.equals(MessageDigest.class)) {
+            return Optional.of(new SHA2(256, DETECTION_LOCATION));
+        }
+        return Optional.empty();
+    }
+}


### PR DESCRIPTION
Fixes #127

## What changed

- Added a metadata-only copy hook to `Algorithm.deepCopy()` so recursive child copying stays centralized while concrete algorithm subtype identity is preserved.
- Added type-specific copy constructors and `shallowCopy()` overrides across `Algorithm` subclasses, including indirect subclasses such as `Ascon128`.
- Updated `RSA` to use the shared `Algorithm.deepCopy()` path instead of duplicating the child-copy loop. This also intentionally preserves `origin`; the previous custom RSA path used the 3-argument `Algorithm` constructor and silently reset origin to the default.
- Defensively copy the children map in the multi-argument `asKind` constructor so recasting cannot mutate the source map. Child `INode` instances remain shared unless callers use `deepCopy()`.
- Added regression coverage for representative subtype preservation, recursive child-copy isolation, metadata preservation, enricher recasting behavior, and all direct `Algorithm` subclasses discovered on the classpath.
- Updated the Go HKDF Expand test expectation that was still pinned to the old subtype-loss behavior. The copied expanded HKDF now remains an `HKDF`, so its `asString()` correctly includes the preserved SHA256 child (`HKDF-SHA256`) and the child is fully enriched with digest metadata.

## Why

`Algorithm.deepCopy()` previously instantiated `new Algorithm(this)`, so calling `deepCopy()` on `AES` and other algorithm subclasses returned a plain `Algorithm`. That broke downstream `instanceof` logic, including enricher behavior and CBOM output decisions.

## Validation

- `mvn -pl mapper,enricher spotless:apply`
- `mvn -pl mapper -am -Dexec.skip=true -Dtest=AlgorithmDeepCopyTest -Dsurefire.failIfNoSpecifiedTests=false test` (`154` AlgorithmDeepCopyTest cases, including `151` direct algorithm subclasses)
- `mvn -pl mapper,enricher -am -Dexec.skip=true test` (mapper/common/engine/enricher pass; mapper `197` tests with `1` existing skip, enricher `28` tests)
- `mvn -pl go -am -Dexec.skip=true -Dtest=GoCryptoHKDFExpandTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -pl go -am -Dexec.skip=true test` (`39` Go tests)
- `mvn -B clean package -Dexec.skip=true`

Note: `-Dexec.skip=true` is needed on Windows because mapper's compile phase otherwise tries to execute `download-cipher-suites.sh` directly and fails with `%1 is not a valid Win32 application`. GitHub Actions runs on Linux, so its normal `mvn -B clean package` path can execute that script.