### PR TITLE
Fix resolution of parameterized dictionary subscriptions

### DIFF
--- a/engine/src/main/java/com/ibm/engine/detection/DetectionStoreWithHook.java
+++ b/engine/src/main/java/com/ibm/engine/detection/DetectionStoreWithHook.java
@@ -139,14 +139,35 @@ public final class DetectionStoreWithHook<R, T, S, P> extends DetectionStore<R, 
         }
 
         List<ResolvedValue<Object, T>> resolvedValues;
+        T expressionToResolve = methodInvocationHookWithParameterResolvement.expressionToResolve();
         if (methodInvocationHookWithParameterResolvement.getParameter()
                 instanceof DetectableParameter<T> detectableParameter) {
-            resolvedValues =
-                    detectionEngine.resolveValuesInInnerScope(
-                            Object.class, argument, detectableParameter.getiValueFactory());
+            if (expressionToResolve != null) {
+                resolvedValues =
+                        detectionEngine.resolveValuesInInnerScope(
+                                Object.class,
+                                methodInvocationHookWithParameterResolvement.methodDefinition(),
+                                methodInvocation,
+                                expressionToResolve,
+                                detectableParameter.getiValueFactory());
+            } else {
+                resolvedValues =
+                        detectionEngine.resolveValuesInInnerScope(
+                                Object.class, argument, detectableParameter.getiValueFactory());
+            }
         } else {
-            resolvedValues =
-                    detectionEngine.resolveValuesInInnerScope(Object.class, argument, null);
+            if (expressionToResolve != null) {
+                resolvedValues =
+                        detectionEngine.resolveValuesInInnerScope(
+                                Object.class,
+                                methodInvocationHookWithParameterResolvement.methodDefinition(),
+                                methodInvocation,
+                                expressionToResolve,
+                                null);
+            } else {
+                resolvedValues =
+                        detectionEngine.resolveValuesInInnerScope(Object.class, argument, null);
+            }
         }
         if (resolvedValues.isEmpty()) {
             detectionEngine.resolveValuesInOuterScope(

--- a/engine/src/main/java/com/ibm/engine/detection/IDetectionEngine.java
+++ b/engine/src/main/java/com/ibm/engine/detection/IDetectionEngine.java
@@ -21,6 +21,7 @@ package com.ibm.engine.detection;
 
 import com.ibm.engine.model.factory.IValueFactory;
 import com.ibm.engine.rule.Parameter;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
@@ -84,6 +85,21 @@ public interface IDetectionEngine<T, S> {
             @Nonnull Class<O> clazz,
             @Nonnull T expression,
             @Nullable IValueFactory<T> valueFactory);
+
+    /**
+     * Resolves an expression from a method definition in the context of a specific method call. The
+     * default implementation returns no values; languages with explicit call-argument mapping can
+     * override it.
+     */
+    @Nonnull
+    default <O> List<ResolvedValue<O, T>> resolveValuesInInnerScope(
+            @Nonnull Class<O> clazz,
+            @Nonnull T methodDefinition,
+            @Nonnull T methodInvocation,
+            @Nonnull T expression,
+            @Nullable IValueFactory<T> valueFactory) {
+        return Collections.emptyList();
+    }
 
     /**
      * Resolves values in the outer scope for a given expression and parameter.

--- a/engine/src/main/java/com/ibm/engine/hooks/MethodInvocationHookWithParameterResolvement.java
+++ b/engine/src/main/java/com/ibm/engine/hooks/MethodInvocationHookWithParameterResolvement.java
@@ -25,13 +25,23 @@ import com.ibm.engine.detection.MethodMatcher;
 import com.ibm.engine.language.ILanguageSupport;
 import com.ibm.engine.rule.Parameter;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 public record MethodInvocationHookWithParameterResolvement<R, T, S, P>(
         @Nonnull T methodDefinition,
         @Nonnull T methodParameter,
         @Nonnull Parameter<T> parameter,
-        @Nonnull MatchContext matchContext)
+        @Nonnull MatchContext matchContext,
+        @Nullable T expressionToResolve)
         implements IMethodInvocationHook<R, T, S, P> {
+
+    public MethodInvocationHookWithParameterResolvement(
+            @Nonnull T methodDefinition,
+            @Nonnull T methodParameter,
+            @Nonnull Parameter<T> parameter,
+            @Nonnull MatchContext matchContext) {
+        this(methodDefinition, methodParameter, parameter, matchContext, null);
+    }
 
     @Nonnull
     @Override

--- a/engine/src/main/java/com/ibm/engine/language/python/PythonDetectionEngine.java
+++ b/engine/src/main/java/com/ibm/engine/language/python/PythonDetectionEngine.java
@@ -26,8 +26,11 @@ import com.ibm.engine.model.factory.IValueFactory;
 import com.ibm.engine.rule.*;
 import com.ibm.engine.rule.Parameter;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -143,6 +146,46 @@ public class PythonDetectionEngine implements IDetectionEngine<Tree, Symbol> {
     }
 
     @Override
+    @Nonnull
+    public <O> List<ResolvedValue<O, Tree>> resolveValuesInInnerScope(
+            @Nonnull Class<O> clazz,
+            @Nonnull Tree methodDefinition,
+            @Nonnull Tree methodInvocation,
+            @Nonnull Tree expression,
+            @Nullable IValueFactory<Tree> valueFactory) {
+        if (!(methodDefinition instanceof FunctionDef methodTree)
+                || !(methodInvocation instanceof CallExpression callExpression)
+                || !(expression instanceof Expression expressionTree)) {
+            return Collections.emptyList();
+        }
+
+        ParameterList parameterList = methodTree.parameters();
+        if (parameterList == null
+                || parameterList.nonTuple().size() != callExpression.arguments().size()) {
+            return Collections.emptyList();
+        }
+
+        Map<org.sonar.plugins.python.api.tree.Parameter, Argument> argsMapping = new HashMap<>();
+        for (org.sonar.plugins.python.api.tree.Parameter parameter : parameterList.nonTuple()) {
+            Argument argument =
+                    (Argument)
+                            extractArgumentFromMethodCaller(
+                                    methodDefinition,
+                                    methodInvocation,
+                                    Objects.requireNonNull(parameter.name()));
+            if (argument != null) {
+                argsMapping.put(parameter, argument);
+            }
+        }
+
+        LinkedList<Map<org.sonar.plugins.python.api.tree.Parameter, Argument>> argsMappingList =
+                new LinkedList<>();
+        argsMappingList.add(argsMapping);
+        return PythonSemantic.resolveValues(
+                clazz, expressionTree, argsMappingList, null, false, this);
+    }
+
+    @Override
     public void resolveValuesInOuterScope(
             @Nonnull final Tree tree, @Nonnull final Parameter<Tree> detectableParameter) {
         Tree expression = tree;
@@ -171,7 +214,7 @@ public class PythonDetectionEngine implements IDetectionEngine<Tree, Symbol> {
             }
             final Tree resolvedParameter = resolvedValues.get(0).tree();
 
-            createAMethodHook(methodTree, resolvedParameter, detectableParameter);
+            createAMethodHook(methodTree, resolvedParameter, detectableParameter, expressionTree);
             // Note that compared to the Java implementation, there is no case where we call
             // `createAMethodHook` with `methodParameter == null`.
             // This is because this case is used in Java to resolve return statements, but this
@@ -183,6 +226,14 @@ public class PythonDetectionEngine implements IDetectionEngine<Tree, Symbol> {
             @Nonnull Tree methodTree,
             @Nullable Tree methodParameter,
             @Nonnull Parameter<Tree> detectableParameter) {
+        createAMethodHook(methodTree, methodParameter, detectableParameter, null);
+    }
+
+    private void createAMethodHook(
+            @Nonnull Tree methodTree,
+            @Nullable Tree methodParameter,
+            @Nonnull Parameter<Tree> detectableParameter,
+            @Nullable Tree expressionToResolve) {
         final MatchContext matchContext =
                 MatchContext.build(true, detectionStore.getDetectionRule());
         if (methodParameter == null) {
@@ -207,7 +258,11 @@ public class PythonDetectionEngine implements IDetectionEngine<Tree, Symbol> {
                         PythonCheck, Tree, Symbol, PythonVisitorContext>
                 methodInvocationHookWithParameterResolvement =
                         new MethodInvocationHookWithParameterResolvement<>(
-                                methodTree, methodParameter, detectableParameter, matchContext);
+                                methodTree,
+                                methodParameter,
+                                detectableParameter,
+                                matchContext,
+                                expressionToResolve);
         if (this.detectionStore
                 instanceof
                 final DetectionStoreWithHook<PythonCheck, Tree, Symbol, PythonVisitorContext>

--- a/engine/src/main/java/com/ibm/engine/language/python/PythonSemantic.java
+++ b/engine/src/main/java/com/ibm/engine/language/python/PythonSemantic.java
@@ -114,10 +114,10 @@ public final class PythonSemantic {
                         null,
                         new LinkedList<>());
         // call would enhance the results
-        final List<Tree> results = new LinkedList<>();
-        for (ResolvedValue<Object, Tree> value : values) {
-            results.add(value.tree());
-        }
+        final List<Tree> results =
+                values.stream()
+                        .map(ResolvedValue::tree)
+                        .collect(java.util.stream.Collectors.toCollection(LinkedList::new));
 
         if (results.isEmpty()) {
             // Tries (with few hope) to obtain the type from the Symbol, otherwise returns "*"
@@ -141,9 +141,10 @@ public final class PythonSemantic {
             switch (resultTree.getKind()) {
                 case NAME:
                     final Name nameTree = (Name) resultTree;
-                    final Optional<String> fullyQualifiedNameTempOptional =
-                            Optional.of(nameTree).map(Name::symbol).map(Symbol::fullyQualifiedName);
-                    String fullyQualifiedNameTemp = fullyQualifiedNameTempOptional.orElse(null);
+                    String fullyQualifiedNameTemp =
+                            Optional.ofNullable(nameTree.symbol())
+                                    .map(Symbol::fullyQualifiedName)
+                                    .orElse(null);
                     if (fullyQualifiedNameTemp != null) {
                         if (nameTree.parent() instanceof FunctionDef) {
                             // When we want to resolve the type of a function definition, we resolve
@@ -218,15 +219,9 @@ public final class PythonSemantic {
      * @return A boolean, {@code true} if at least one IType in {@code typesList} is of type {@code
      *     stringType}
      */
-    private static Boolean resolveMultipleTypes(
+    private static boolean resolveMultipleTypes(
             @Nonnull String stringType, @Nonnull List<IType> typesList) {
-        boolean result = false;
-        for (IType iType : typesList) {
-            if (iType.is(stringType)) {
-                result = true;
-            }
-        }
-        return result;
+        return typesList.stream().anyMatch(iType -> iType.is(stringType));
     }
 
     /**
@@ -259,11 +254,10 @@ public final class PythonSemantic {
         }
 
         if (wantedStringType.endsWith(".*")) {
+            String prefix = wantedStringType.substring(0, wantedStringType.length() - 2);
             result =
-                    fullyQualifiedNameStringType.startsWith(
-                                    wantedStringType.substring(0, wantedStringType.length() - 2))
-                            || shortenedFullyQualifiedNameStringType.startsWith(
-                                    wantedStringType.substring(0, wantedStringType.length() - 2));
+                    fullyQualifiedNameStringType.startsWith(prefix)
+                            || shortenedFullyQualifiedNameStringType.startsWith(prefix);
         } else {
             result =
                     fullyQualifiedNameStringType.equals(wantedStringType)
@@ -726,17 +720,17 @@ public final class PythonSemantic {
             SubscriptionExpression subscriptionExpressionTree = (SubscriptionExpression) tree;
             List<Expression> subscriptionIndexList =
                     subscriptionExpressionTree.subscripts().expressions();
-            if (subscriptionIndexList.size()
-                    == 1) { // TODO: for now, we only resolve the precise subscription index when
-                // there is only one index
+            if (subscriptionIndexList.size() == 1) {
                 Expression currentSubscriptionIndex = subscriptionIndexList.get(0);
+
                 // The index may not be immediately an int or a string: there can be intermediary
-                // assignments, that we resolve
+                // assignments, that we resolve. Keep the current argument mappings so an index that
+                // is a parameter of the enclosing function can be resolved from the call context.
                 List<ResolvedValue<O, Tree>> resolvedSubscriptionIndexList =
                         resolveValues(
                                 clazz,
                                 currentSubscriptionIndex,
-                                new LinkedList<>(),
+                                new LinkedList<>(argsMappingList),
                                 null,
                                 returnEnclosingParam,
                                 false,
@@ -747,13 +741,12 @@ public final class PythonSemantic {
                     Tree resolvedSubscriptionIndex = resolvedValue.tree();
 
                     if (resolvedSubscriptionIndex instanceof NumericLiteral indexLiteralTree) {
-                        // Case of lists: `list[1]`
                         Object index = getNumericValue(indexLiteralTree);
                         result.addAll(
                                 resolveValues(
                                         clazz,
                                         subscriptionExpressionTree.object(),
-                                        argsMappingList,
+                                        new LinkedList<>(argsMappingList),
                                         index,
                                         returnEnclosingParam,
                                         isResolvingType,
@@ -761,13 +754,12 @@ public final class PythonSemantic {
                                         alreadyResolvedTrees));
                     } else if (resolvedSubscriptionIndex
                             instanceof StringLiteral indexLiteralTree) {
-                        // Case of dictionaries: `dict["key"]`
                         String index = (String) (indexLiteralTree.trimmedQuotesValue());
                         List<ResolvedValue<O, Tree>> resolveDictResult =
                                 resolveValues(
                                         clazz,
                                         subscriptionExpressionTree.object(),
-                                        argsMappingList,
+                                        new LinkedList<>(argsMappingList),
                                         index,
                                         returnEnclosingParam,
                                         isResolvingType,
@@ -790,9 +782,9 @@ public final class PythonSemantic {
                         }
                     } else if (returnEnclosingParam && resolvedSubscriptionIndex instanceof Name) {
                         // Case of a subscription `struct[some_var]` where some_var is an argument
-                        // of the current enclosing function
+                        // of the current enclosing function.
                         // In the case of outer scope resolution with returnEnclosingParam set to
-                        // true, we return this argument Name
+                        // true, we return this argument Name.
                         result.addAll(
                                 resolveValues(
                                         clazz,

--- a/python/src/test/files/rules/resolve/ResolveValuesWithHooksTestFile.py
+++ b/python/src/test/files/rules/resolve/ResolveValuesWithHooksTestFile.py
@@ -49,3 +49,13 @@ def fun17(arg17):
 def fun18():
     private_key = fun17(ec.SECP384R1()) # Noncompliant {{SECP384R1}}
     return private_key
+
+# Resolve an outer parameter that is used as a dictionary subscription index
+curve_table = {
+    b'ecdsa-sha2-nistp256': ec.SECP256R1(),
+    b'ecdsa-sha2-nistp384': ec.SECP384R1(),
+    b'ecdsa-sha2-nistp521': ec.SECP521R1(),
+}
+def fun19(curve):
+    return ec.generate_private_key(curve_table[curve])
+private_key = fun19(b'ecdsa-sha2-nistp256') # Noncompliant {{SECP256R1}}


### PR DESCRIPTION
Fixes #10 

Fix the resolution of dictionary subscriptions using function parameters. Preserve argument mappings when resolving subscription expressions and re-resolve outer-scope hook expressions using call-site arguments. This allows expressions such as _curveTable[curve] to resolve through dictionary lookups and correctly identify values like SECP256R1. Added a regression test.