### PR TITLE
feat(java): propagate JCA provider metadata to CBOM output

### DIFF
--- a/engine/src/main/java/com/ibm/engine/model/Provider.java
+++ b/engine/src/main/java/com/ibm/engine/model/Provider.java
@@ -1,0 +1,68 @@
+/*
+ * Sonar Cryptography Plugin
+ * Copyright (C) 2024 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.engine.model;
+
+import javax.annotation.Nonnull;
+
+public class Provider<T> extends AbstractValue<T> {
+    @Nonnull private final String value;
+    @Nonnull private final T location;
+
+    public Provider(@Nonnull String value, @Nonnull T location) {
+        this.location = location;
+        this.value = value;
+    }
+
+    @Nonnull
+    public String get() {
+        return value;
+    }
+
+    @Override
+    @Nonnull
+    public T getLocation() {
+        return location;
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+
+    @Nonnull
+    @Override
+    public String asString() {
+        return this.value;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Provider<?> provider)) return false;
+        return value.equals(provider.value) && getLocation().equals(provider.getLocation());
+    }
+
+    @Override
+    public int hashCode() {
+        int result = value.hashCode();
+        result = 31 * result + getLocation().hashCode();
+        return result;
+    }
+}

--- a/engine/src/main/java/com/ibm/engine/model/factory/ProviderFactory.java
+++ b/engine/src/main/java/com/ibm/engine/model/factory/ProviderFactory.java
@@ -1,0 +1,38 @@
+/*
+ * Sonar Cryptography Plugin
+ * Copyright (C) 2024 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.engine.model.factory;
+
+import com.ibm.engine.detection.ResolvedValue;
+import com.ibm.engine.model.IValue;
+import com.ibm.engine.model.Provider;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+
+public class ProviderFactory<T> implements IValueFactory<T> {
+
+    @Nonnull
+    @Override
+    public Optional<IValue<T>> apply(@Nonnull ResolvedValue<Object, T> objectTResolvedValue) {
+        if (objectTResolvedValue.value() instanceof String str) {
+            return Optional.of(new Provider<>(str, objectTResolvedValue.tree()));
+        }
+        return Optional.empty();
+    }
+}

--- a/java/src/main/java/com/ibm/plugin/rules/detection/jca/algorithmparametergenerator/JcaAlgorithmParameterGeneratorGetInstance.java
+++ b/java/src/main/java/com/ibm/plugin/rules/detection/jca/algorithmparametergenerator/JcaAlgorithmParameterGeneratorGetInstance.java
@@ -23,6 +23,7 @@ import static com.ibm.plugin.rules.detection.TypeShortcuts.STRING_TYPE;
 
 import com.ibm.engine.model.context.AlgorithmParameterContext;
 import com.ibm.engine.model.factory.AlgorithmFactory;
+import com.ibm.engine.model.factory.ProviderFactory;
 import com.ibm.engine.rule.IDetectionRule;
 import com.ibm.engine.rule.builder.DetectionRuleBuilder;
 import java.util.List;
@@ -49,6 +50,8 @@ public final class JcaAlgorithmParameterGeneratorGetInstance {
                     .withMethodParameter(STRING_TYPE)
                     .shouldBeDetectedAs(new AlgorithmFactory<>())
                     .withMethodParameter("java.security.Provider")
+                    .shouldBeDetectedAs(new ProviderFactory<>())
+                    .asChildOfParameterWithId(0)
                     .buildForContext(new AlgorithmParameterContext())
                     .inBundle(() -> "Jca")
                     .withDependingDetectionRules(JcaAlgorithmParameterGeneratorInit.rules());
@@ -61,6 +64,8 @@ public final class JcaAlgorithmParameterGeneratorGetInstance {
                     .withMethodParameter(STRING_TYPE)
                     .shouldBeDetectedAs(new AlgorithmFactory<>())
                     .withMethodParameter(STRING_TYPE)
+                    .shouldBeDetectedAs(new ProviderFactory<>())
+                    .asChildOfParameterWithId(0)
                     .buildForContext(new AlgorithmParameterContext())
                     .inBundle(() -> "Jca")
                     .withDependingDetectionRules(JcaAlgorithmParameterGeneratorInit.rules());

--- a/java/src/main/java/com/ibm/plugin/rules/detection/jca/cipher/JcaCipherGetInstance.java
+++ b/java/src/main/java/com/ibm/plugin/rules/detection/jca/cipher/JcaCipherGetInstance.java
@@ -24,6 +24,7 @@ import static com.ibm.plugin.rules.detection.TypeShortcuts.STRING_TYPE;
 
 import com.ibm.engine.model.context.CipherContext;
 import com.ibm.engine.model.factory.AlgorithmFactory;
+import com.ibm.engine.model.factory.ProviderFactory;
 import com.ibm.engine.rule.IDetectionRule;
 import com.ibm.engine.rule.builder.DetectionRuleBuilder;
 import java.util.List;
@@ -57,6 +58,8 @@ public final class JcaCipherGetInstance {
                     .withMethodParameter(STRING_TYPE)
                     .shouldBeDetectedAs(new AlgorithmFactory<>())
                     .withMethodParameter(STRING_TYPE)
+                    .shouldBeDetectedAs(new ProviderFactory<>())
+                    .asChildOfParameterWithId(0)
                     .buildForContext(new CipherContext())
                     .inBundle(() -> "Jca")
                     .withDependingDetectionRules(
@@ -73,6 +76,8 @@ public final class JcaCipherGetInstance {
                     .withMethodParameter(STRING_TYPE)
                     .shouldBeDetectedAs(new AlgorithmFactory<>())
                     .withMethodParameter("java.security.Provider")
+                    .shouldBeDetectedAs(new ProviderFactory<>())
+                    .asChildOfParameterWithId(0)
                     .buildForContext(new CipherContext())
                     .inBundle(() -> "Jca")
                     .withDependingDetectionRules(

--- a/java/src/main/java/com/ibm/plugin/rules/detection/jca/digest/JcaMessageDigestGetInstance.java
+++ b/java/src/main/java/com/ibm/plugin/rules/detection/jca/digest/JcaMessageDigestGetInstance.java
@@ -23,6 +23,7 @@ import static com.ibm.plugin.rules.detection.TypeShortcuts.STRING_TYPE;
 
 import com.ibm.engine.model.context.DigestContext;
 import com.ibm.engine.model.factory.AlgorithmFactory;
+import com.ibm.engine.model.factory.ProviderFactory;
 import com.ibm.engine.rule.IDetectionRule;
 import com.ibm.engine.rule.builder.DetectionRuleBuilder;
 import java.util.List;
@@ -50,6 +51,8 @@ public final class JcaMessageDigestGetInstance {
                     .withMethodParameter(STRING_TYPE)
                     .shouldBeDetectedAs(new AlgorithmFactory<>())
                     .withMethodParameter(STRING_TYPE)
+                    .shouldBeDetectedAs(new ProviderFactory<>())
+                    .asChildOfParameterWithId(0)
                     .buildForContext(new DigestContext())
                     .inBundle(() -> "Jca")
                     .withoutDependingDetectionRules();
@@ -62,6 +65,8 @@ public final class JcaMessageDigestGetInstance {
                     .withMethodParameter(STRING_TYPE)
                     .shouldBeDetectedAs(new AlgorithmFactory<>())
                     .withMethodParameter("java.security.Provider")
+                    .shouldBeDetectedAs(new ProviderFactory<>())
+                    .asChildOfParameterWithId(0)
                     .buildForContext(new DigestContext())
                     .inBundle(() -> "Jca")
                     .withoutDependingDetectionRules();

--- a/java/src/main/java/com/ibm/plugin/rules/detection/jca/keyagreement/JcaKeyAgreementGetInstance.java
+++ b/java/src/main/java/com/ibm/plugin/rules/detection/jca/keyagreement/JcaKeyAgreementGetInstance.java
@@ -23,6 +23,7 @@ import static com.ibm.plugin.rules.detection.TypeShortcuts.STRING_TYPE;
 
 import com.ibm.engine.model.context.KeyAgreementContext;
 import com.ibm.engine.model.factory.AlgorithmFactory;
+import com.ibm.engine.model.factory.ProviderFactory;
 import com.ibm.engine.rule.IDetectionRule;
 import com.ibm.engine.rule.builder.DetectionRuleBuilder;
 import java.util.List;
@@ -55,6 +56,8 @@ public final class JcaKeyAgreementGetInstance {
                     .withMethodParameter(STRING_TYPE)
                     .shouldBeDetectedAs(new AlgorithmFactory<>())
                     .withMethodParameter("java.security.Provider")
+                    .shouldBeDetectedAs(new ProviderFactory<>())
+                    .asChildOfParameterWithId(0)
                     .buildForContext(new KeyAgreementContext())
                     .inBundle(() -> "Jca")
                     .withDependingDetectionRules(
@@ -71,6 +74,8 @@ public final class JcaKeyAgreementGetInstance {
                     .withMethodParameter(STRING_TYPE)
                     .shouldBeDetectedAs(new AlgorithmFactory<>())
                     .withMethodParameter(STRING_TYPE)
+                    .shouldBeDetectedAs(new ProviderFactory<>())
+                    .asChildOfParameterWithId(0)
                     .buildForContext(new KeyAgreementContext())
                     .inBundle(() -> "Jca")
                     .withDependingDetectionRules(

--- a/java/src/main/java/com/ibm/plugin/rules/detection/jca/keyfactory/JcaKeyFactoryGetInstance.java
+++ b/java/src/main/java/com/ibm/plugin/rules/detection/jca/keyfactory/JcaKeyFactoryGetInstance.java
@@ -23,6 +23,7 @@ import static com.ibm.plugin.rules.detection.TypeShortcuts.STRING_TYPE;
 
 import com.ibm.engine.model.context.KeyContext;
 import com.ibm.engine.model.factory.AlgorithmFactory;
+import com.ibm.engine.model.factory.ProviderFactory;
 import com.ibm.engine.rule.IDetectionRule;
 import com.ibm.engine.rule.builder.DetectionRuleBuilder;
 import java.util.List;
@@ -50,6 +51,8 @@ public final class JcaKeyFactoryGetInstance {
                     .withMethodParameter(STRING_TYPE)
                     .shouldBeDetectedAs(new AlgorithmFactory<>())
                     .withMethodParameter(STRING_TYPE)
+                    .shouldBeDetectedAs(new ProviderFactory<>())
+                    .asChildOfParameterWithId(0)
                     .buildForContext(new KeyContext(KeyContext.Kind.NONE))
                     .inBundle(() -> "Jca")
                     .withDependingDetectionRules(JcaKeyFactoryGenerate.rules());
@@ -62,6 +65,8 @@ public final class JcaKeyFactoryGetInstance {
                     .withMethodParameter(STRING_TYPE)
                     .shouldBeDetectedAs(new AlgorithmFactory<>())
                     .withMethodParameter("java.security.Provider")
+                    .shouldBeDetectedAs(new ProviderFactory<>())
+                    .asChildOfParameterWithId(0)
                     .buildForContext(new KeyContext(KeyContext.Kind.NONE))
                     .inBundle(() -> "Jca")
                     .withDependingDetectionRules(JcaKeyFactoryGenerate.rules());

--- a/java/src/main/java/com/ibm/plugin/rules/detection/jca/keyfactory/JcaSecretKeyFactoryGetInstance.java
+++ b/java/src/main/java/com/ibm/plugin/rules/detection/jca/keyfactory/JcaSecretKeyFactoryGetInstance.java
@@ -24,6 +24,7 @@ import static com.ibm.plugin.rules.detection.TypeShortcuts.STRING_TYPE;
 import com.ibm.engine.model.context.KeyContext;
 import com.ibm.engine.model.context.SecretKeyContext;
 import com.ibm.engine.model.factory.AlgorithmFactory;
+import com.ibm.engine.model.factory.ProviderFactory;
 import com.ibm.engine.rule.IDetectionRule;
 import com.ibm.engine.rule.builder.DetectionRuleBuilder;
 import java.util.List;
@@ -56,6 +57,8 @@ public final class JcaSecretKeyFactoryGetInstance {
                     .withMethodParameter(STRING_TYPE)
                     .shouldBeDetectedAs(new AlgorithmFactory<>())
                     .withMethodParameter(STRING_TYPE)
+                    .shouldBeDetectedAs(new ProviderFactory<>())
+                    .asChildOfParameterWithId(0)
                     .buildForContext(new SecretKeyContext(KeyContext.Kind.NONE))
                     .inBundle(() -> "Jca")
                     .withDependingDetectionRules(
@@ -72,6 +75,8 @@ public final class JcaSecretKeyFactoryGetInstance {
                     .withMethodParameter(STRING_TYPE)
                     .shouldBeDetectedAs(new AlgorithmFactory<>())
                     .withMethodParameter("java.security.Provider")
+                    .shouldBeDetectedAs(new ProviderFactory<>())
+                    .asChildOfParameterWithId(0)
                     .buildForContext(new SecretKeyContext(KeyContext.Kind.NONE))
                     .inBundle(() -> "Jca")
                     .withDependingDetectionRules(

--- a/java/src/main/java/com/ibm/plugin/rules/detection/jca/keygenerator/JcaKeyGeneratorGetInstance.java
+++ b/java/src/main/java/com/ibm/plugin/rules/detection/jca/keygenerator/JcaKeyGeneratorGetInstance.java
@@ -23,6 +23,7 @@ import static com.ibm.plugin.rules.detection.TypeShortcuts.STRING_TYPE;
 
 import com.ibm.engine.model.context.KeyContext;
 import com.ibm.engine.model.factory.AlgorithmFactory;
+import com.ibm.engine.model.factory.ProviderFactory;
 import com.ibm.engine.rule.IDetectionRule;
 import com.ibm.engine.rule.builder.DetectionRuleBuilder;
 import java.util.List;
@@ -50,6 +51,8 @@ public final class JcaKeyGeneratorGetInstance {
                     .withMethodParameter(STRING_TYPE)
                     .shouldBeDetectedAs(new AlgorithmFactory<>())
                     .withMethodParameter(STRING_TYPE)
+                    .shouldBeDetectedAs(new ProviderFactory<>())
+                    .asChildOfParameterWithId(0)
                     .buildForContext(new KeyContext(KeyContext.Kind.NONE))
                     .inBundle(() -> "Jca")
                     .withDependingDetectionRules(JcaKeyGeneratorInit.rules());
@@ -62,6 +65,8 @@ public final class JcaKeyGeneratorGetInstance {
                     .withMethodParameter(STRING_TYPE)
                     .shouldBeDetectedAs(new AlgorithmFactory<>())
                     .withMethodParameter("java.security.Provider")
+                    .shouldBeDetectedAs(new ProviderFactory<>())
+                    .asChildOfParameterWithId(0)
                     .buildForContext(new KeyContext(KeyContext.Kind.NONE))
                     .inBundle(() -> "Jca")
                     .withDependingDetectionRules(JcaKeyGeneratorInit.rules());

--- a/java/src/main/java/com/ibm/plugin/rules/detection/jca/keygenerator/JcaKeyPairGeneratorGetInstance.java
+++ b/java/src/main/java/com/ibm/plugin/rules/detection/jca/keygenerator/JcaKeyPairGeneratorGetInstance.java
@@ -23,6 +23,7 @@ import static com.ibm.plugin.rules.detection.TypeShortcuts.STRING_TYPE;
 
 import com.ibm.engine.model.context.KeyContext;
 import com.ibm.engine.model.factory.AlgorithmFactory;
+import com.ibm.engine.model.factory.ProviderFactory;
 import com.ibm.engine.rule.IDetectionRule;
 import com.ibm.engine.rule.builder.DetectionRuleBuilder;
 import java.util.List;
@@ -50,6 +51,8 @@ public final class JcaKeyPairGeneratorGetInstance {
                     .withMethodParameter(STRING_TYPE)
                     .shouldBeDetectedAs(new AlgorithmFactory<>())
                     .withMethodParameter(STRING_TYPE)
+                    .shouldBeDetectedAs(new ProviderFactory<>())
+                    .asChildOfParameterWithId(0)
                     .buildForContext(new KeyContext(KeyContext.Kind.NONE))
                     .inBundle(() -> "Jca")
                     .withDependingDetectionRules(JcaKeyPairGeneratorInitialize.rules());
@@ -62,6 +65,8 @@ public final class JcaKeyPairGeneratorGetInstance {
                     .withMethodParameter(STRING_TYPE)
                     .shouldBeDetectedAs(new AlgorithmFactory<>())
                     .withMethodParameter("java.security.Provider")
+                    .shouldBeDetectedAs(new ProviderFactory<>())
+                    .asChildOfParameterWithId(0)
                     .buildForContext(new KeyContext(KeyContext.Kind.NONE))
                     .inBundle(() -> "Jca")
                     .withDependingDetectionRules(JcaKeyPairGeneratorInitialize.rules());

--- a/java/src/main/java/com/ibm/plugin/rules/detection/jca/mac/JcaMacGetInstance.java
+++ b/java/src/main/java/com/ibm/plugin/rules/detection/jca/mac/JcaMacGetInstance.java
@@ -23,6 +23,7 @@ import static com.ibm.plugin.rules.detection.TypeShortcuts.STRING_TYPE;
 
 import com.ibm.engine.model.context.MacContext;
 import com.ibm.engine.model.factory.AlgorithmFactory;
+import com.ibm.engine.model.factory.ProviderFactory;
 import com.ibm.engine.rule.IDetectionRule;
 import com.ibm.engine.rule.builder.DetectionRuleBuilder;
 import java.util.List;
@@ -50,6 +51,8 @@ public final class JcaMacGetInstance {
                     .withMethodParameter(STRING_TYPE)
                     .shouldBeDetectedAs(new AlgorithmFactory<>())
                     .withMethodParameter(STRING_TYPE)
+                    .shouldBeDetectedAs(new ProviderFactory<>())
+                    .asChildOfParameterWithId(0)
                     .buildForContext(new MacContext())
                     .inBundle(() -> "Jca")
                     .withoutDependingDetectionRules();

--- a/java/src/main/java/com/ibm/plugin/rules/detection/jca/signature/JcaSignatureGetInstance.java
+++ b/java/src/main/java/com/ibm/plugin/rules/detection/jca/signature/JcaSignatureGetInstance.java
@@ -23,6 +23,7 @@ import static com.ibm.plugin.rules.detection.TypeShortcuts.STRING_TYPE;
 
 import com.ibm.engine.model.context.SignatureContext;
 import com.ibm.engine.model.factory.AlgorithmFactory;
+import com.ibm.engine.model.factory.ProviderFactory;
 import com.ibm.engine.rule.IDetectionRule;
 import com.ibm.engine.rule.builder.DetectionRuleBuilder;
 import java.util.List;
@@ -55,6 +56,8 @@ public final class JcaSignatureGetInstance {
                     .withMethodParameter(STRING_TYPE)
                     .shouldBeDetectedAs(new AlgorithmFactory<>())
                     .withMethodParameter(STRING_TYPE)
+                    .shouldBeDetectedAs(new ProviderFactory<>())
+                    .asChildOfParameterWithId(0)
                     .buildForContext(new SignatureContext())
                     .inBundle(() -> "Jca")
                     .withDependingDetectionRules(
@@ -71,6 +74,8 @@ public final class JcaSignatureGetInstance {
                     .withMethodParameter(STRING_TYPE)
                     .shouldBeDetectedAs(new AlgorithmFactory<>())
                     .withMethodParameter("java.security.Provider")
+                    .shouldBeDetectedAs(new ProviderFactory<>())
+                    .asChildOfParameterWithId(0)
                     .buildForContext(new SignatureContext())
                     .inBundle(() -> "Jca")
                     .withDependingDetectionRules(

--- a/java/src/main/java/com/ibm/plugin/translation/translator/contexts/JavaAlgorithmParameterContextTranslator.java
+++ b/java/src/main/java/com/ibm/plugin/translation/translator/contexts/JavaAlgorithmParameterContextTranslator.java
@@ -25,6 +25,7 @@ import com.ibm.engine.model.InitializationVectorSize;
 import com.ibm.engine.model.KeySize;
 import com.ibm.engine.model.MacSize;
 import com.ibm.engine.model.Mode;
+import com.ibm.engine.model.Provider;
 import com.ibm.engine.model.TagSize;
 import com.ibm.engine.model.context.IDetectionContext;
 import com.ibm.mapper.mapper.jca.JcaAlgorithmMapper;
@@ -48,6 +49,9 @@ public final class JavaAlgorithmParameterContextTranslator extends JavaAbstractL
         if (value instanceof Algorithm<Tree>) {
             JcaAlgorithmMapper jcaAlgorithmMapper = new JcaAlgorithmMapper();
             return jcaAlgorithmMapper.parse(value.asString(), detectionLocation).map(a -> a);
+        } else if (value instanceof Provider<Tree> provider) {
+            return Optional.of(
+                    new com.ibm.mapper.model.Provider(provider.get(), detectionLocation));
         }
         return translateCommon(value, detectionContext, detectionLocation);
     }

--- a/java/src/main/java/com/ibm/plugin/translation/translator/contexts/JavaCipherContextTranslator.java
+++ b/java/src/main/java/com/ibm/plugin/translation/translator/contexts/JavaCipherContextTranslator.java
@@ -25,6 +25,7 @@ import com.ibm.engine.model.BlockSize;
 import com.ibm.engine.model.CipherAction;
 import com.ibm.engine.model.IValue;
 import com.ibm.engine.model.OperationMode;
+import com.ibm.engine.model.Provider;
 import com.ibm.engine.model.ValueAction;
 import com.ibm.engine.model.context.DetectionContext;
 import com.ibm.engine.model.context.IDetectionContext;
@@ -66,6 +67,9 @@ public final class JavaCipherContextTranslator extends JavaAbstractLibraryTransl
         if (value instanceof Algorithm<Tree>) {
             JcaAlgorithmMapper jcaAlgorithmMapper = new JcaAlgorithmMapper();
             return jcaAlgorithmMapper.parse(value.asString(), detectionLocation).map(a -> a);
+        } else if (value instanceof Provider<Tree> provider) {
+            return Optional.of(
+                    new com.ibm.mapper.model.Provider(provider.get(), detectionLocation));
         } else if (value instanceof OperationMode<Tree> operationMode) {
             JcaCipherOperationModeMapper jcaCipherOperationModeMapper =
                     new JcaCipherOperationModeMapper();

--- a/java/src/main/java/com/ibm/plugin/translation/translator/contexts/JavaDigestContextTranslator.java
+++ b/java/src/main/java/com/ibm/plugin/translation/translator/contexts/JavaDigestContextTranslator.java
@@ -21,6 +21,7 @@ package com.ibm.plugin.translation.translator.contexts;
 
 import com.ibm.engine.model.Algorithm;
 import com.ibm.engine.model.IValue;
+import com.ibm.engine.model.Provider;
 import com.ibm.engine.model.ValueAction;
 import com.ibm.engine.model.context.DetectionContext;
 import com.ibm.engine.model.context.IDetectionContext;
@@ -54,6 +55,9 @@ public final class JavaDigestContextTranslator extends JavaAbstractLibraryTransl
                                 algo.put(new Digest(detectionLocation));
                                 return algo;
                             });
+        } else if (value instanceof Provider<Tree> provider) {
+            return Optional.of(
+                    new com.ibm.mapper.model.Provider(provider.get(), detectionLocation));
         }
         return Optional.empty();
     }

--- a/java/src/main/java/com/ibm/plugin/translation/translator/contexts/JavaKeyAgreementContextTranslator.java
+++ b/java/src/main/java/com/ibm/plugin/translation/translator/contexts/JavaKeyAgreementContextTranslator.java
@@ -23,6 +23,7 @@ import com.ibm.engine.model.Algorithm;
 import com.ibm.engine.model.IValue;
 import com.ibm.engine.model.KeyAction;
 import com.ibm.engine.model.KeySize;
+import com.ibm.engine.model.Provider;
 import com.ibm.engine.model.context.IDetectionContext;
 import com.ibm.mapper.mapper.jca.JcaAlgorithmMapper;
 import com.ibm.mapper.model.INode;
@@ -45,6 +46,9 @@ public final class JavaKeyAgreementContextTranslator extends JavaAbstractLibrary
             return jcaAlgorithmMapper
                     .parse(algorithm.asString(), detectionLocation)
                     .map(iNode -> (com.ibm.mapper.model.Algorithm) iNode);
+        } else if (value instanceof Provider<Tree> provider) {
+            return Optional.of(
+                    new com.ibm.mapper.model.Provider(provider.get(), detectionLocation));
         } else if (value instanceof KeySize<Tree> keySize) {
             KeyLength keyLength = new KeyLength(keySize.getValue(), detectionLocation);
             return Optional.of(keyLength);

--- a/java/src/main/java/com/ibm/plugin/translation/translator/contexts/JavaKeyContextTranslator.java
+++ b/java/src/main/java/com/ibm/plugin/translation/translator/contexts/JavaKeyContextTranslator.java
@@ -26,6 +26,7 @@ import com.ibm.engine.model.IValue;
 import com.ibm.engine.model.KeyAction;
 import com.ibm.engine.model.KeySize;
 import com.ibm.engine.model.OperationMode;
+import com.ibm.engine.model.Provider;
 import com.ibm.engine.model.ValueAction;
 import com.ibm.engine.model.context.DetectionContext;
 import com.ibm.engine.model.context.IDetectionContext;
@@ -85,6 +86,9 @@ public final class JavaKeyContextTranslator extends JavaAbstractLibraryTranslato
                                 }
                                 return key;
                             });
+        } else if (value instanceof Provider<Tree> provider) {
+            return Optional.of(
+                    new com.ibm.mapper.model.Provider(provider.get(), detectionLocation));
         } else if (value instanceof KeySize<Tree> keySize) {
             final KeyLength keyLength = new KeyLength(keySize.getValue(), detectionLocation);
             return Optional.of(keyLength);

--- a/java/src/main/java/com/ibm/plugin/translation/translator/contexts/JavaMacContextTranslator.java
+++ b/java/src/main/java/com/ibm/plugin/translation/translator/contexts/JavaMacContextTranslator.java
@@ -23,6 +23,7 @@ import com.ibm.engine.model.BlockSize;
 import com.ibm.engine.model.IValue;
 import com.ibm.engine.model.MacSize;
 import com.ibm.engine.model.ParameterIdentifier;
+import com.ibm.engine.model.Provider;
 import com.ibm.engine.model.ValueAction;
 import com.ibm.engine.model.context.IDetectionContext;
 import com.ibm.mapper.mapper.bc.BcMacMapper;
@@ -45,6 +46,9 @@ public final class JavaMacContextTranslator extends JavaAbstractLibraryTranslato
         if (value instanceof com.ibm.engine.model.Algorithm<Tree>) {
             JcaMacMapper jcaMacMapper = new JcaMacMapper();
             return jcaMacMapper.parse(value.asString(), detectionLocation).map(a -> a);
+        } else if (value instanceof Provider<Tree> provider) {
+            return Optional.of(
+                    new com.ibm.mapper.model.Provider(provider.get(), detectionLocation));
         } else if (value instanceof MacSize<Tree> macSize) {
             TagLength tagLength = new TagLength(macSize.getValue(), detectionLocation);
             return Optional.of(tagLength);

--- a/java/src/main/java/com/ibm/plugin/translation/translator/contexts/JavaSecretKeyContextTranslator.java
+++ b/java/src/main/java/com/ibm/plugin/translation/translator/contexts/JavaSecretKeyContextTranslator.java
@@ -23,6 +23,7 @@ import com.ibm.engine.model.Algorithm;
 import com.ibm.engine.model.IValue;
 import com.ibm.engine.model.KeySize;
 import com.ibm.engine.model.PasswordSize;
+import com.ibm.engine.model.Provider;
 import com.ibm.engine.model.SaltSize;
 import com.ibm.engine.model.context.IDetectionContext;
 import com.ibm.mapper.mapper.jca.JcaAlgorithmMapper;
@@ -62,6 +63,9 @@ public final class JavaSecretKeyContextTranslator extends JavaAbstractLibraryTra
                                 return algo;
                             })
                     .map(SecretKey::new);
+        } else if (value instanceof Provider<Tree> provider) {
+            return Optional.of(
+                    new com.ibm.mapper.model.Provider(provider.get(), detectionLocation));
         } else if (value instanceof KeySize<Tree> keySize) {
             KeyLength keyLength = new KeyLength(keySize.getValue(), detectionLocation);
             return Optional.of(keyLength);

--- a/java/src/main/java/com/ibm/plugin/translation/translator/contexts/JavaSignatureContextTranslator.java
+++ b/java/src/main/java/com/ibm/plugin/translation/translator/contexts/JavaSignatureContextTranslator.java
@@ -22,6 +22,7 @@ package com.ibm.plugin.translation.translator.contexts;
 import com.ibm.engine.model.AlgorithmParameter;
 import com.ibm.engine.model.IValue;
 import com.ibm.engine.model.OperationMode;
+import com.ibm.engine.model.Provider;
 import com.ibm.engine.model.SaltSize;
 import com.ibm.engine.model.SignatureAction;
 import com.ibm.engine.model.ValueAction;
@@ -52,6 +53,9 @@ public final class JavaSignatureContextTranslator extends JavaAbstractLibraryTra
         if (value instanceof com.ibm.engine.model.Algorithm<Tree>) {
             final JcaAlgorithmMapper jcaAlgorithmMapper = new JcaAlgorithmMapper();
             return jcaAlgorithmMapper.parse(value.asString(), detectionLocation).map(a -> a);
+        } else if (value instanceof Provider<Tree> provider) {
+            return Optional.of(
+                    new com.ibm.mapper.model.Provider(provider.get(), detectionLocation));
         } else if (value instanceof SignatureAction<Tree> signatureAction) {
             return switch (signatureAction.getAction()) {
                 case SIGN -> Optional.of(new Sign(detectionLocation));

--- a/java/src/test/java/com/ibm/plugin/rules/detection/bc/other/BcSM2EngineTest.java
+++ b/java/src/test/java/com/ibm/plugin/rules/detection/bc/other/BcSM2EngineTest.java
@@ -35,6 +35,7 @@ import com.ibm.mapper.model.INode;
 import com.ibm.mapper.model.Key;
 import com.ibm.mapper.model.MessageDigest;
 import com.ibm.mapper.model.Oid;
+import com.ibm.mapper.model.Provider;
 import com.ibm.mapper.model.PublicKeyEncryption;
 import com.ibm.mapper.model.functionality.Digest;
 import com.ibm.mapper.model.functionality.Encrypt;
@@ -85,8 +86,13 @@ class BcSM2EngineTest extends TestBase {
             // Key
             INode keyNode = nodes.get(0);
             assertThat(keyNode.getKind()).isEqualTo(Key.class);
-            assertThat(keyNode.getChildren()).hasSize(1);
+            assertThat(keyNode.getChildren()).hasSize(2);
             assertThat(keyNode.asString()).isEqualTo("EC");
+
+            // Provider "BC" under Key (from KeyPairGenerator.getInstance("EC", "BC"))
+            INode providerNode = keyNode.getChildren().get(Provider.class);
+            assertThat(providerNode).isNotNull();
+            assertThat(providerNode.asString()).isEqualTo("BC");
 
             // PublicKeyEncryption under Key
             INode publicKeyEncryptionNode = keyNode.getChildren().get(PublicKeyEncryption.class);

--- a/java/src/test/java/com/ibm/plugin/rules/detection/jca/digest/JcaMessageDigestGetInstance2Test.java
+++ b/java/src/test/java/com/ibm/plugin/rules/detection/jca/digest/JcaMessageDigestGetInstance2Test.java
@@ -30,6 +30,7 @@ import com.ibm.mapper.model.DigestSize;
 import com.ibm.mapper.model.INode;
 import com.ibm.mapper.model.MessageDigest;
 import com.ibm.mapper.model.Oid;
+import com.ibm.mapper.model.Provider;
 import com.ibm.mapper.model.functionality.Digest;
 import com.ibm.plugin.TestBase;
 import java.util.List;
@@ -76,7 +77,6 @@ class JcaMessageDigestGetInstance2Test extends TestBase {
         // MessageDigest
         INode messageDigestNode1 = nodes.get(0);
         assertThat(messageDigestNode1.getKind()).isEqualTo(MessageDigest.class);
-        assertThat(messageDigestNode1.getChildren()).hasSize(4);
         assertThat(messageDigestNode1.asString()).isEqualTo("SHA384");
 
         // Oid under MessageDigest
@@ -102,5 +102,17 @@ class JcaMessageDigestGetInstance2Test extends TestBase {
         assertThat(blockSizeNode1).isNotNull();
         assertThat(blockSizeNode1.getChildren()).isEmpty();
         assertThat(blockSizeNode1.asString()).isEqualTo("1024");
+
+        if (findingId == 0) {
+            // Finding from getInstance("sha-384", provider[0]): java.security.Provider object,
+            // not resolved as String, so no Provider child
+            assertThat(messageDigestNode1.getChildren()).hasSize(4);
+        } else {
+            // Finding from getInstance("sha-384", "SUN"): String provider is captured
+            assertThat(messageDigestNode1.getChildren()).hasSize(5);
+            INode providerNode1 = messageDigestNode1.getChildren().get(Provider.class);
+            assertThat(providerNode1).isNotNull();
+            assertThat(providerNode1.asString()).isEqualTo("SUN");
+        }
     }
 }

--- a/mapper/src/main/java/com/ibm/mapper/model/Provider.java
+++ b/mapper/src/main/java/com/ibm/mapper/model/Provider.java
@@ -1,0 +1,73 @@
+/*
+ * Sonar Cryptography Plugin
+ * Copyright (C) 2024 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.mapper.model;
+
+import com.ibm.mapper.utils.DetectionLocation;
+import java.util.Objects;
+import javax.annotation.Nonnull;
+
+public final class Provider extends Property {
+
+    @Nonnull private final String name;
+
+    public Provider(@Nonnull String name, @Nonnull DetectionLocation detectionLocation) {
+        super(Provider.class, detectionLocation);
+        this.name = name;
+    }
+
+    private Provider(@Nonnull Provider provider) {
+        super(Provider.class, provider.detectionLocation, provider.children);
+        this.name = provider.name;
+    }
+
+    @Nonnull
+    public String getName() {
+        return name;
+    }
+
+    @Nonnull
+    @Override
+    public String asString() {
+        return name;
+    }
+
+    @Nonnull
+    @Override
+    public INode deepCopy() {
+        Provider copy = new Provider(this);
+        for (INode child : this.children.values()) {
+            copy.children.put(child.getKind(), child.deepCopy());
+        }
+        return copy;
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) return true;
+        if (!(object instanceof Provider provider)) return false;
+        if (!super.equals(object)) return false;
+        return Objects.equals(name, provider.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), name);
+    }
+}

--- a/output/src/main/java/com/ibm/output/cyclondx/CBOMOutputFile.java
+++ b/output/src/main/java/com/ibm/output/cyclondx/CBOMOutputFile.java
@@ -38,6 +38,7 @@ import com.ibm.mapper.model.Padding;
 import com.ibm.mapper.model.ParameterSetIdentifier;
 import com.ibm.mapper.model.PasswordLength;
 import com.ibm.mapper.model.Protocol;
+import com.ibm.mapper.model.Provider;
 import com.ibm.mapper.model.SaltLength;
 import com.ibm.mapper.model.collections.CipherSuiteCollection;
 import com.ibm.mapper.model.functionality.Decapsulate;
@@ -164,6 +165,7 @@ public class CBOMOutputFile implements IOutputFile {
                         .primitive(node)
                         .occurrences(createOccurrenceForm(node.getDetectionContext()))
                         .oid(children.get(Oid.class))
+                        .provider(children.get(Provider.class))
                         .build();
         final Optional<String> optionalId = getIdentifierFunction().apply(algorithm);
         if (optionalId.isEmpty()) {
@@ -182,6 +184,7 @@ public class CBOMOutputFile implements IOutputFile {
         // will get the same key length associated.
         Utils.pushNodesDownToFirstMatch(
                 node, IPrimitive.getKinds(), List.of(KeyLength.class), false);
+        Utils.pushNodesDownToFirstMatch(node, IPrimitive.getKinds(), List.of(Provider.class));
 
         createRelatedCryptoMaterialComponent(parentBomRef, node);
     }

--- a/output/src/main/java/com/ibm/output/cyclondx/builder/AlgorithmComponentBuilder.java
+++ b/output/src/main/java/com/ibm/output/cyclondx/builder/AlgorithmComponentBuilder.java
@@ -81,6 +81,8 @@ import org.cyclonedx.model.component.crypto.enums.Primitive;
 import org.cyclonedx.model.component.evidence.Occurrence;
 
 public class AlgorithmComponentBuilder implements IAlgorithmComponentBuilder {
+    private static final String JCA_PROVIDER_PROPERTY = "jca-provider";
+
     @Nonnull private final Component component;
     @Nonnull private final CryptoProperties cryptoProperties;
     @Nonnull private final AlgorithmProperties algorithmProperties;
@@ -431,9 +433,12 @@ public class AlgorithmComponentBuilder implements IAlgorithmComponentBuilder {
     @Override
     public @Nonnull IAlgorithmComponentBuilder provider(@Nullable INode provider) {
         if (provider instanceof Provider p) {
-            List<org.cyclonedx.model.Property> props = new ArrayList<>();
+            List<org.cyclonedx.model.Property> props = this.component.getProperties();
+            if (props == null) {
+                props = new ArrayList<>();
+            }
             org.cyclonedx.model.Property prop = new org.cyclonedx.model.Property();
-            prop.setName("jca-provider");
+            prop.setName(JCA_PROVIDER_PROPERTY);
             prop.setValue(p.getName());
             props.add(prop);
             this.component.setProperties(props);

--- a/output/src/main/java/com/ibm/output/cyclondx/builder/AlgorithmComponentBuilder.java
+++ b/output/src/main/java/com/ibm/output/cyclondx/builder/AlgorithmComponentBuilder.java
@@ -33,6 +33,7 @@ import com.ibm.mapper.model.Oid;
 import com.ibm.mapper.model.PasswordBasedEncryption;
 import com.ibm.mapper.model.PasswordBasedKeyDerivationFunction;
 import com.ibm.mapper.model.ProbabilisticSignatureScheme;
+import com.ibm.mapper.model.Provider;
 import com.ibm.mapper.model.PseudorandomNumberGenerator;
 import com.ibm.mapper.model.PublicKeyEncryption;
 import com.ibm.mapper.model.Signature;
@@ -60,6 +61,7 @@ import com.ibm.mapper.model.padding.OAEP;
 import com.ibm.mapper.model.padding.PKCS1;
 import com.ibm.mapper.model.padding.PKCS5;
 import com.ibm.mapper.model.padding.PKCS7;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -88,6 +90,7 @@ public class AlgorithmComponentBuilder implements IAlgorithmComponentBuilder {
     @Nullable private INode mode;
     @Nullable private INode padding;
     @Nullable private INode curve;
+    @Nullable private INode provider;
 
     protected AlgorithmComponentBuilder() {
         this.component = new Component();
@@ -104,7 +107,8 @@ public class AlgorithmComponentBuilder implements IAlgorithmComponentBuilder {
             @Nullable INode parameterSetIdentifier,
             @Nullable INode mode,
             @Nullable INode padding,
-            @Nullable INode curve) {
+            @Nullable INode curve,
+            @Nullable INode provider) {
         this.component = component;
         this.cryptoProperties = cryptoProperties;
         this.algorithmProperties = algorithmProperties;
@@ -113,6 +117,7 @@ public class AlgorithmComponentBuilder implements IAlgorithmComponentBuilder {
         this.mode = mode;
         this.padding = padding;
         this.curve = curve;
+        this.provider = provider;
     }
 
     @Nonnull
@@ -131,7 +136,8 @@ public class AlgorithmComponentBuilder implements IAlgorithmComponentBuilder {
                 parameterSetIdentifier,
                 mode,
                 padding,
-                curve);
+                curve,
+                provider);
     }
 
     @Override
@@ -145,7 +151,8 @@ public class AlgorithmComponentBuilder implements IAlgorithmComponentBuilder {
                 parameterSetIdentifier,
                 mode,
                 padding,
-                curve);
+                curve,
+                provider);
     }
 
     @Override
@@ -159,7 +166,8 @@ public class AlgorithmComponentBuilder implements IAlgorithmComponentBuilder {
                     parameterSetIdentifier,
                     this.mode,
                     padding,
-                    curve);
+                    curve,
+                    provider);
         }
         this.mode = mode;
         Mode cxMode;
@@ -189,7 +197,8 @@ public class AlgorithmComponentBuilder implements IAlgorithmComponentBuilder {
                 parameterSetIdentifier,
                 mode,
                 padding,
-                curve);
+                curve,
+                provider);
     }
 
     @Override
@@ -203,7 +212,8 @@ public class AlgorithmComponentBuilder implements IAlgorithmComponentBuilder {
                     parameterSetIdentifier,
                     mode,
                     padding,
-                    curve);
+                    curve,
+                    provider);
         }
         Primitive primitives;
         if (primitive.is(AuthenticatedEncryption.class)) {
@@ -245,7 +255,8 @@ public class AlgorithmComponentBuilder implements IAlgorithmComponentBuilder {
                 parameterSetIdentifier,
                 mode,
                 padding,
-                curve);
+                curve,
+                provider);
     }
 
     @Override
@@ -259,7 +270,8 @@ public class AlgorithmComponentBuilder implements IAlgorithmComponentBuilder {
                     parameterSetIdentifier,
                     mode,
                     this.padding,
-                    curve);
+                    curve,
+                    provider);
         }
 
         this.padding = padding;
@@ -284,7 +296,8 @@ public class AlgorithmComponentBuilder implements IAlgorithmComponentBuilder {
                 parameterSetIdentifier,
                 mode,
                 padding,
-                curve);
+                curve,
+                provider);
     }
 
     @Override
@@ -301,7 +314,8 @@ public class AlgorithmComponentBuilder implements IAlgorithmComponentBuilder {
                 parameterSetIdentifier,
                 mode,
                 padding,
-                curve);
+                curve,
+                provider);
     }
 
     @Override
@@ -315,7 +329,8 @@ public class AlgorithmComponentBuilder implements IAlgorithmComponentBuilder {
                     parameterSetIdentifier,
                     mode,
                     padding,
-                    curve);
+                    curve,
+                    provider);
         }
 
         List<CryptoFunction> functions =
@@ -361,7 +376,8 @@ public class AlgorithmComponentBuilder implements IAlgorithmComponentBuilder {
                 parameterSetIdentifier,
                 mode,
                 padding,
-                curve);
+                curve,
+                provider);
     }
 
     @Override
@@ -375,7 +391,8 @@ public class AlgorithmComponentBuilder implements IAlgorithmComponentBuilder {
                     parameterSetIdentifier,
                     mode,
                     padding,
-                    curve);
+                    curve,
+                    provider);
         }
 
         final Evidence evidence = new Evidence();
@@ -390,7 +407,8 @@ public class AlgorithmComponentBuilder implements IAlgorithmComponentBuilder {
                 parameterSetIdentifier,
                 mode,
                 padding,
-                curve);
+                curve,
+                provider);
     }
 
     @Override
@@ -406,7 +424,30 @@ public class AlgorithmComponentBuilder implements IAlgorithmComponentBuilder {
                 parameterSetIdentifier,
                 mode,
                 padding,
-                curve);
+                curve,
+                provider);
+    }
+
+    @Override
+    public @Nonnull IAlgorithmComponentBuilder provider(@Nullable INode provider) {
+        if (provider instanceof Provider p) {
+            List<org.cyclonedx.model.Property> props = new ArrayList<>();
+            org.cyclonedx.model.Property prop = new org.cyclonedx.model.Property();
+            prop.setName("jca-provider");
+            prop.setValue(p.getName());
+            props.add(prop);
+            this.component.setProperties(props);
+        }
+        return new AlgorithmComponentBuilder(
+                component,
+                cryptoProperties,
+                algorithmProperties,
+                algorithm,
+                parameterSetIdentifier,
+                mode,
+                padding,
+                curve,
+                provider);
     }
 
     @Override

--- a/output/src/main/java/com/ibm/output/cyclondx/builder/IAlgorithmComponentBuilder.java
+++ b/output/src/main/java/com/ibm/output/cyclondx/builder/IAlgorithmComponentBuilder.java
@@ -54,5 +54,8 @@ public interface IAlgorithmComponentBuilder {
     IAlgorithmComponentBuilder oid(@Nullable INode oid);
 
     @Nonnull
+    IAlgorithmComponentBuilder provider(@Nullable INode provider);
+
+    @Nonnull
     Component build();
 }

--- a/output/src/test/java/com/ibm/output/cyclonedx/AlgorithmTest.java
+++ b/output/src/test/java/com/ibm/output/cyclonedx/AlgorithmTest.java
@@ -24,11 +24,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.ibm.mapper.model.EllipticCurveAlgorithm;
 import com.ibm.mapper.model.KeyLength;
 import com.ibm.mapper.model.Oid;
+import com.ibm.mapper.model.Provider;
 import com.ibm.mapper.model.PasswordBasedKeyDerivationFunction;
 import com.ibm.mapper.model.PasswordLength;
 import com.ibm.mapper.model.PrivateKey;
 import com.ibm.mapper.model.PublicKeyEncryption;
 import com.ibm.mapper.model.SaltLength;
+import com.ibm.mapper.model.algorithms.AES;
 import com.ibm.mapper.model.algorithms.DSA;
 import com.ibm.mapper.model.algorithms.ECDH;
 import com.ibm.mapper.model.algorithms.MGF1;
@@ -46,6 +48,7 @@ import com.ibm.mapper.model.functionality.KeyGeneration;
 import com.ibm.mapper.model.functionality.Sign;
 import com.ibm.mapper.model.padding.OAEP;
 import org.cyclonedx.model.Component;
+import org.cyclonedx.model.Property;
 import org.cyclonedx.model.component.crypto.AlgorithmProperties;
 import org.cyclonedx.model.component.crypto.CryptoProperties;
 import org.cyclonedx.model.component.crypto.RelatedCryptoMaterialProperties;
@@ -408,6 +411,29 @@ class AlgorithmTest extends TestBase {
                     assertThat(algorithmProperties.getPrimitive()).isEqualTo(Primitive.KEY_AGREE);
                     assertThat(algorithmProperties.getCurve()).isEqualTo("secp384r1");
                     assertThat(cryptoProperties.getOid()).isEqualTo("1.3.132.1.12");
+                });
+    }
+
+    @Test
+    void algorithmWithJcaProvider() {
+        this.assertsNode(
+                () -> {
+                    final AES aes = new AES(detectionLocation);
+                    aes.put(new Provider("BC", detectionLocation));
+                    return aes;
+                },
+                bom -> {
+                    assertThat(bom.getComponents()).hasSize(1);
+                    Component component = bom.getComponents().get(0);
+                    assertThat(component.getName()).isEqualTo("AES");
+
+                    assertThat(component.getProperties()).isNotNull();
+                    assertThat(component.getProperties())
+                            .extracting(Property::getName)
+                            .contains("jca-provider");
+                    assertThat(component.getProperties())
+                            .extracting(Property::getValue)
+                            .contains("BC");
                 });
     }
 }


### PR DESCRIPTION
## Summary

This PR adds support for capturing and propagating JCA provider metadata through the analysis pipeline and into CBOM output.

Provider information supplied to JCA APIs such as:

```java
Cipher.getInstance("AES/CBC/PKCS5Padding", "BC");
MessageDigest.getInstance("SHA-256", "SUN");
```

was previously accepted during rule matching but discarded before translation and CBOM generation.

This change preserves provider information throughout the pipeline and emits it as a CBOM component property.

## Changes

### Engine

Added a new provider detection model:

* `Provider`
* `ProviderFactory`

The factory resolves provider names from String-based provider arguments and creates provider detections that can be attached to existing JCA detections.

### Detection Rules

Updated JCA `getInstance()` rules to capture provider parameters and attach them to the corresponding algorithm detection:

* Cipher
* MessageDigest
* Mac
* Signature
* KeyAgreement
* KeyFactory
* SecretKeyFactory
* KeyGenerator
* KeyPairGenerator
* AlgorithmParameterGenerator

Provider detections are attached as child detections of the primary algorithm parameter.

### Translation

Added provider translation support across all relevant JCA context translators.

A new mapper-level `Provider` model is introduced to carry provider metadata through the translation layer.

### CBOM Output

Provider metadata is now emitted as a CycloneDX component property:

```json
{
  "name": "jca-provider",
  "value": "BC"
}
```

The output builder was updated to support provider metadata and to correctly propagate providers for key-related JCA detections.

## Example

Input:

```java
Cipher.getInstance("AES/CBC/PKCS5Padding", "BC");
```

Output:

```json
{
  "properties": [
    {
      "name": "jca-provider",
      "value": "BC"
    }
  ]
}
```

## Testing

Updated and extended tests to validate provider propagation:

* `BcSM2EngineTest`
* `JcaMessageDigestGetInstance2Test`

Verification performed:

* All Java tests pass
* Full project build succeeds

## Notes

This PR focuses on provider detection, propagation, and CBOM representation.

Provider-aware rule behavior and provider-specific analysis can be implemented as follow-up work on top of this foundation.

Related to #32
