### PR TITLE
fix: detect pyca stream ciphers with mode=None

### DIFF
--- a/python/src/main/java/com/ibm/plugin/rules/detection/symmetric/PycaCipher.java
+++ b/python/src/main/java/com/ibm/plugin/rules/detection/symmetric/PycaCipher.java
@@ -101,8 +101,23 @@ public final class PycaCipher {
                     .inBundle(() -> "Pyca")
                     .withoutDependingDetectionRules();
 
+    private static final IDetectionRule<Tree> STREAM_CIPHER =
+            new DetectionRuleBuilder<Tree>()
+                    .createDetectionRule()
+                    .forObjectTypes("cryptography.hazmat.primitives.ciphers")
+                    .forMethods("Cipher")
+                    .withMethodParameter("cryptography.hazmat.primitives.ciphers.algorithms.*")
+                    .shouldBeDetectedAs(new AlgorithmFactory<>())
+                    .addDependingDetectionRules(followingNewCipherRules())
+                    .withMethodParameter("None")
+                    .shouldBeDetectedAs(new ModeFactory<>())
+                    .asChildOfParameterWithId(0)
+                    .buildForContext(new CipherContext())
+                    .inBundle(() -> "Pyca")
+                    .withoutDependingDetectionRules();
+
     @Nonnull
     public static List<IDetectionRule<Tree>> rules() {
-        return List.of(NEW_CIPHER);
+        return List.of(NEW_CIPHER, STREAM_CIPHER);
     }
 }

--- a/python/src/test/files/rules/detection/symmetric/PycaStreamCipher1TestFile.py
+++ b/python/src/test/files/rules/detection/symmetric/PycaStreamCipher1TestFile.py
@@ -1,0 +1,11 @@
+import os
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
+key = os.urandom(32)
+iv = os.urandom(16)
+# Create a cipher object
+cipher = Cipher(algorithms.ChaCha20(key, nonce), mode=None) # Noncompliant {{(StreamCipher) ChaCha20}}
+
+# Encrypt
+encryptor = cipher.encryptor()
+ct = encryptor.update(b"a secret message") + encryptor.finalize()

--- a/python/src/test/java/com/ibm/plugin/rules/detection/symmetric/PycaStreamCipher1Test.java
+++ b/python/src/test/java/com/ibm/plugin/rules/detection/symmetric/PycaStreamCipher1Test.java
@@ -1,0 +1,89 @@
+/*
+ * Sonar Cryptography Plugin
+ * Copyright (C) 2024 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.plugin.rules.detection.symmetric;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ibm.engine.detection.DetectionStore;
+import com.ibm.engine.model.Algorithm;
+import com.ibm.engine.model.CipherAction;
+import com.ibm.engine.model.IValue;
+import com.ibm.engine.model.context.CipherContext;
+import com.ibm.mapper.model.INode;
+import com.ibm.mapper.model.StreamCipher;
+import com.ibm.mapper.model.functionality.Encrypt;
+import com.ibm.plugin.TestBase;
+import java.util.List;
+import javax.annotation.Nonnull;
+import org.junit.jupiter.api.Test;
+import org.sonar.plugins.python.api.PythonCheck;
+import org.sonar.plugins.python.api.PythonVisitorContext;
+import org.sonar.plugins.python.api.symbols.Symbol;
+import org.sonar.plugins.python.api.tree.Tree;
+import org.sonar.python.checks.utils.PythonCheckVerifier;
+
+class PycaStreamCipher1Test extends TestBase {
+
+    @Test
+    void test() {
+        PythonCheckVerifier.verify(
+                "src/test/files/rules/detection/symmetric/PycaStreamCipher1TestFile.py", this);
+    }
+
+    @Override
+    public void asserts(
+            int findingId,
+            @Nonnull DetectionStore<PythonCheck, Tree, Symbol, PythonVisitorContext> detectionStore,
+            @Nonnull List<INode> nodes) {
+        /*
+         * Detection Store
+         */
+        assertThat(detectionStore.getDetectionValues()).hasSize(1);
+        assertThat(detectionStore.getDetectionValueContext()).isInstanceOf(CipherContext.class);
+        IValue<Tree> value0 = detectionStore.getDetectionValues().get(0);
+        assertThat(value0).isInstanceOf(Algorithm.class);
+        assertThat(value0.asString()).isEqualTo("ChaCha20");
+
+        DetectionStore<PythonCheck, Tree, Symbol, PythonVisitorContext> store_1 =
+                getStoreOfValueType(CipherAction.class, detectionStore.getChildren());
+        assertThat(store_1.getDetectionValues()).hasSize(1);
+        assertThat(store_1.getDetectionValueContext()).isInstanceOf(CipherContext.class);
+        IValue<Tree> value0_1 = store_1.getDetectionValues().get(0);
+        assertThat(value0_1).isInstanceOf(CipherAction.class);
+        assertThat(value0_1.asString()).isEqualTo("ENCRYPT");
+
+        /*
+         * Translation
+         */
+        assertThat(nodes).hasSize(1);
+
+        // StreamCipher
+        INode streamCipherNode = nodes.get(0);
+        assertThat(streamCipherNode.getKind()).isEqualTo(StreamCipher.class);
+        assertThat(streamCipherNode.getChildren()).hasSize(1);
+        assertThat(streamCipherNode.asString()).isEqualTo("ChaCha20");
+
+        // Encrypt under BlockCipher
+        INode encryptNode = streamCipherNode.getChildren().get(Encrypt.class);
+        assertThat(encryptNode).isNotNull();
+        assertThat(encryptNode.getChildren()).isEmpty();
+        assertThat(encryptNode.asString()).isEqualTo("ENCRYPT");
+    }
+}


### PR DESCRIPTION
The existing block cipher detection rule requires the mode parameter to match `cryptography.hazmat.primitives.ciphers.modes.*`.

Stream ciphers such as `ChaCha20` do not use a cipher mode and are initialised with `mode=None`, so they were not detected.

This PR adds a detection rule for stream ciphers initialised with `mode=None`.


A test file and unit test were added for `Cipher(algorithms.ChaCha20(...), mode=None)`. The test passes successfully.