### PR TITLE
Fix asset deduplication logic

### DIFF
--- a/java/src/main/java/com/ibm/plugin/translation/reorganizer/JavaReorganizerRules.java
+++ b/java/src/main/java/com/ibm/plugin/translation/reorganizer/JavaReorganizerRules.java
@@ -45,6 +45,7 @@ public final class JavaReorganizerRules {
                 AeadBlockCipherReorganizer.MOVE_TAG_LENGTH_UNDER_MAC,
                 AsymmetricBlockCipherReorganizer.INVERT_DIGEST_AND_ITS_SIZE,
                 AsymmetricBlockCipherReorganizer.MERGE_PKE_PARENT_AND_CHILD,
+                BlockCipherReorganizer.DEDUPLICATE_OVERLAPPING_ROOTS,
                 BlockCipherReorganizer.MERGE_BLOCK_CIPHER_PARENT_AND_CHILD,
                 CipherParameterReorganizer.MOVE_KEY_LENGTH_UNDER_TAG_LENGTH_UP,
                 CipherParameterReorganizer.MOVE_NODES_UNDER_DECRYPT_UP,

--- a/mapper/src/main/java/com/ibm/mapper/reorganizer/rules/BlockCipherReorganizer.java
+++ b/mapper/src/main/java/com/ibm/mapper/reorganizer/rules/BlockCipherReorganizer.java
@@ -73,58 +73,77 @@ public final class BlockCipherReorganizer {
                 @Nullable @Override
                 public List<INode> applyReorganization(
                         @Nonnull INode node, @Nonnull INode parent, @Nonnull List<INode> roots) {
-                    if (!(node instanceof Algorithm algA)) {
+                    if (!(node instanceof Algorithm)) {
                         return roots;
                     }
 
                     List<INode> newRoots = new ArrayList<>(roots);
-                    INode toRemove = null;
-                    INode toKeep = null;
+                    INode currentBase = node;
+                    boolean merged;
+                    do {
+                        merged = false;
+                        INode toRemove = null;
+                        INode toKeep = null;
 
-                    for (INode other : newRoots) {
-                        if (other != node && other instanceof Algorithm algB) {
+                        for (INode other : newRoots) {
+                            if (other != currentBase && other instanceof Algorithm algB) {
+                                Algorithm baseAlg = (Algorithm) currentBase;
 
-                            if (algA.getDetectionContext().equals(algB.getDetectionContext())
-                                    && isRelatedCipherFamily(algA.getName(), algB.getName())) {
+                                if (baseAlg.getDetectionContext().equals(algB.getDetectionContext())
+                                        && isRelatedCipherFamily(
+                                                baseAlg.getName(), algB.getName())) {
 
-                                String nameA = algA.getName();
-                                String nameB = algB.getName();
+                                    String nameA = baseAlg.getName().trim();
+                                    String nameB = algB.getName().trim();
 
-                                if (nameA.equalsIgnoreCase("Unknown")) {
-                                    toKeep = other;
-                                    toRemove = node;
-                                } else if (nameB.equalsIgnoreCase("Unknown")) {
-                                    toKeep = node;
-                                    toRemove = other;
-                                } else if (nameA.length() >= nameB.length()) {
-                                    toKeep = node;
-                                    toRemove = other;
-                                } else {
-                                    toKeep = other;
-                                    toRemove = node;
+                                    if (nameA.equalsIgnoreCase("Unknown") || nameA.isEmpty()) {
+                                        toKeep = other;
+                                        toRemove = currentBase;
+                                    } else if (nameB.equalsIgnoreCase("Unknown")
+                                            || nameB.isEmpty()) {
+                                        toKeep = currentBase;
+                                        toRemove = other;
+                                    } else if (nameA.length() >= nameB.length()) {
+                                        toKeep = currentBase;
+                                        toRemove = other;
+                                    } else {
+                                        toKeep = other;
+                                        toRemove = currentBase;
+                                    }
+                                    break;
                                 }
-                                break;
                             }
                         }
-                    }
 
-                    if (toRemove != null) {
-                        for (INode child : toRemove.getChildren().values()) {
-                            if (!toKeep.getChildren().containsKey(child.getKind())) {
-                                toKeep.put(child);
+                        if (toRemove != null) {
+                            // Merge non-conflicting children from the removed node into the
+                            // retained node. Existing children take precedence when both
+                            // nodes contain the same child kind.
+                            for (INode child : toRemove.getChildren().values()) {
+                                if (!toKeep.getChildren().containsKey(child.getKind())) {
+                                    toKeep.put(child);
+                                }
                             }
+                            newRoots.remove(toRemove);
+                            currentBase = toKeep;
+                            merged = true;
                         }
-                        newRoots.remove(toRemove);
-                    }
+                    } while (merged);
 
                     return newRoots;
                 }
 
                 private boolean isRelatedCipherFamily(String nameA, String nameB) {
-                    String safeA = nameA != null ? nameA : "Unknown";
-                    String safeB = nameB != null ? nameB : "Unknown";
+                    String safeA =
+                            (nameA != null && !nameA.trim().isEmpty())
+                                    ? nameA.trim().toUpperCase()
+                                    : "UNKNOWN";
+                    String safeB =
+                            (nameB != null && !nameB.trim().isEmpty())
+                                    ? nameB.trim().toUpperCase()
+                                    : "UNKNOWN";
 
-                    if (safeA.equalsIgnoreCase("Unknown") || safeB.equalsIgnoreCase("Unknown")) {
+                    if (safeA.equals("UNKNOWN") || safeB.equals("UNKNOWN")) {
                         return true;
                     }
 
@@ -137,6 +156,8 @@ public final class BlockCipherReorganizer {
 
                     if (longer.startsWith(shorter)) {
                         char nextChar = longer.charAt(shorter.length());
+                        // Require a non-alphanumeric separator after the shared prefix to
+                        // avoid false-positive matches between unrelated algorithm names.
                         return !Character.isLetterOrDigit(nextChar);
                     }
 

--- a/mapper/src/main/java/com/ibm/mapper/reorganizer/rules/BlockCipherReorganizer.java
+++ b/mapper/src/main/java/com/ibm/mapper/reorganizer/rules/BlockCipherReorganizer.java
@@ -19,11 +19,16 @@
  */
 package com.ibm.mapper.reorganizer.rules;
 
+import com.ibm.mapper.model.Algorithm;
 import com.ibm.mapper.model.BlockCipher;
+import com.ibm.mapper.model.INode;
 import com.ibm.mapper.reorganizer.IReorganizerRule;
 import com.ibm.mapper.reorganizer.UsualPerformActions;
 import com.ibm.mapper.reorganizer.builder.ReorganizerRuleBuilder;
+import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 public final class BlockCipherReorganizer {
 
@@ -44,4 +49,110 @@ public final class BlockCipherReorganizer {
                     .perform(
                             UsualPerformActions.performMergeParentAndChildOfSameKind(
                                     BlockCipher.class));
+
+    public static final IReorganizerRule DEDUPLICATE_OVERLAPPING_ROOTS =
+            new IReorganizerRule() {
+                @Override
+                public boolean match(
+                        @Nonnull INode node, @Nonnull INode parent, @Nonnull List<INode> roots) {
+                    if (!roots.contains(node) || !(node instanceof Algorithm algA)) {
+                        return false;
+                    }
+
+                    for (INode other : roots) {
+                        if (other != node && other instanceof Algorithm algB) {
+                            if (algA.getDetectionContext().equals(algB.getDetectionContext())
+                                    && isRelatedCipherFamily(algA.getName(), algB.getName())) {
+                                return true;
+                            }
+                        }
+                    }
+                    return false;
+                }
+
+                @Nullable @Override
+                public List<INode> applyReorganization(
+                        @Nonnull INode node, @Nonnull INode parent, @Nonnull List<INode> roots) {
+                    if (!(node instanceof Algorithm algA)) {
+                        return roots;
+                    }
+
+                    List<INode> newRoots = new ArrayList<>(roots);
+                    INode toRemove = null;
+                    INode toKeep = null;
+
+                    for (INode other : newRoots) {
+                        if (other != node && other instanceof Algorithm algB) {
+
+                            if (algA.getDetectionContext().equals(algB.getDetectionContext())
+                                    && isRelatedCipherFamily(algA.getName(), algB.getName())) {
+
+                                String nameA = algA.getName();
+                                String nameB = algB.getName();
+
+                                if (nameA.equalsIgnoreCase("Unknown")) {
+                                    toKeep = other;
+                                    toRemove = node;
+                                } else if (nameB.equalsIgnoreCase("Unknown")) {
+                                    toKeep = node;
+                                    toRemove = other;
+                                } else if (nameA.length() >= nameB.length()) {
+                                    toKeep = node;
+                                    toRemove = other;
+                                } else {
+                                    toKeep = other;
+                                    toRemove = node;
+                                }
+                                break;
+                            }
+                        }
+                    }
+
+                    if (toRemove != null) {
+                        for (INode child : toRemove.getChildren().values()) {
+                            if (!toKeep.getChildren().containsKey(child.getKind())) {
+                                toKeep.put(child);
+                            }
+                        }
+                        newRoots.remove(toRemove);
+                    }
+
+                    return newRoots;
+                }
+
+                private boolean isRelatedCipherFamily(String nameA, String nameB) {
+                    String safeA = nameA != null ? nameA : "Unknown";
+                    String safeB = nameB != null ? nameB : "Unknown";
+
+                    if (safeA.equalsIgnoreCase("Unknown") || safeB.equalsIgnoreCase("Unknown")) {
+                        return true;
+                    }
+
+                    String shorter = safeA.length() < safeB.length() ? safeA : safeB;
+                    String longer = safeA.length() < safeB.length() ? safeB : safeA;
+
+                    if (shorter.equals(longer)) {
+                        return true;
+                    }
+
+                    if (longer.startsWith(shorter)) {
+                        char nextChar = longer.charAt(shorter.length());
+                        return !Character.isLetterOrDigit(nextChar);
+                    }
+
+                    return false;
+                }
+
+                @Nonnull
+                @Override
+                public String asString() {
+                    return "DEDUPLICATE_OVERLAPPING_ROOTS";
+                }
+
+                @Nonnull
+                @Override
+                public Class<? extends INode> getNodeKind() {
+                    return BlockCipher.class;
+                }
+            };
 }

--- a/mapper/src/test/java/com/ibm/mapper/mapper/jca/BlockCipherReorganizerTest.java
+++ b/mapper/src/test/java/com/ibm/mapper/mapper/jca/BlockCipherReorganizerTest.java
@@ -21,6 +21,7 @@ package com.ibm.mapper.mapper.jca;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.ibm.mapper.mapper.bc.BcBlockCipherEngineMapper;
 import com.ibm.mapper.mapper.bc.BcBlockCipherModeMapper;
@@ -123,5 +124,78 @@ class BlockCipherReorganizerTest {
                 .as(
                         "The merged node should retain the inner child properties (like Mode and KeyLength)")
                 .isNotEmpty();
+    }
+
+    @Test
+    @DisplayName(
+            "Edge Case: Should safely iterate and deduplicate 3+ overlapping roots into a single node")
+    void shouldDeduplicateMultipleOverlappingRoots() {
+        IReorganizerRule rule = BlockCipherReorganizer.DEDUPLICATE_OVERLAPPING_ROOTS;
+
+        Algorithm unknownWrapper = mock(Algorithm.class);
+        when(unknownWrapper.getName()).thenReturn("Unknown");
+        when(unknownWrapper.getDetectionContext()).thenReturn(SHARED_LOCATION_CONTEXT);
+
+        Algorithm aesBase = mock(Algorithm.class);
+        when(aesBase.getName()).thenReturn("AES");
+        when(aesBase.getDetectionContext()).thenReturn(SHARED_LOCATION_CONTEXT);
+
+        Algorithm aesSpecific = mock(Algorithm.class);
+        when(aesSpecific.getName()).thenReturn("AES-256");
+        when(aesSpecific.getDetectionContext()).thenReturn(SHARED_LOCATION_CONTEXT);
+
+        List<INode> roots = new ArrayList<>(List.of(unknownWrapper, aesBase, aesSpecific));
+
+        boolean isMatch = rule.match(unknownWrapper, DUMMY_PARENT, roots);
+        List<INode> optimizedRoots = rule.applyReorganization(unknownWrapper, DUMMY_PARENT, roots);
+
+        assertThat(isMatch).isTrue();
+        assertThat(optimizedRoots).hasSize(1);
+
+        Algorithm remainingAlg = (Algorithm) optimizedRoots.get(0);
+        assertThat(remainingAlg.getName()).isEqualTo("AES-256");
+    }
+
+    @Test
+    @DisplayName("Edge Case: Should NOT merge ambiguous prefixes like RC2 and RC256")
+    void shouldNotMergeAmbiguousPrefixes() {
+        IReorganizerRule rule = BlockCipherReorganizer.DEDUPLICATE_OVERLAPPING_ROOTS;
+
+        Algorithm rc2 = mock(Algorithm.class);
+        when(rc2.getName()).thenReturn("RC2");
+        when(rc2.getDetectionContext()).thenReturn(SHARED_LOCATION_CONTEXT);
+
+        Algorithm rc256 = mock(Algorithm.class);
+        when(rc256.getName()).thenReturn("RC256");
+        when(rc256.getDetectionContext()).thenReturn(SHARED_LOCATION_CONTEXT);
+
+        List<INode> roots = new ArrayList<>(List.of(rc2, rc256));
+
+        boolean isMatch = rule.match(rc2, DUMMY_PARENT, roots);
+
+        assertThat(isMatch).isFalse();
+    }
+
+    @Test
+    @DisplayName("Edge Case: Should handle empty strings and distinct case-sensitivity safely")
+    void shouldHandleEmptyStringsAndCasing() {
+        IReorganizerRule rule = BlockCipherReorganizer.DEDUPLICATE_OVERLAPPING_ROOTS;
+
+        Algorithm emptyNode = mock(Algorithm.class);
+        when(emptyNode.getName()).thenReturn("   "); // Blank spaces
+        when(emptyNode.getDetectionContext()).thenReturn(SHARED_LOCATION_CONTEXT);
+
+        Algorithm lowerCaseAes = mock(Algorithm.class);
+        when(lowerCaseAes.getName()).thenReturn("aes"); // Lowercase
+        when(lowerCaseAes.getDetectionContext()).thenReturn(SHARED_LOCATION_CONTEXT);
+
+        List<INode> roots = new ArrayList<>(List.of(emptyNode, lowerCaseAes));
+
+        boolean isMatch = rule.match(emptyNode, DUMMY_PARENT, roots);
+        List<INode> optimizedRoots = rule.applyReorganization(emptyNode, DUMMY_PARENT, roots);
+
+        assertThat(isMatch).isTrue();
+        assertThat(optimizedRoots).hasSize(1);
+        assertThat(((Algorithm) optimizedRoots.get(0)).getName()).isEqualTo("aes");
     }
 }

--- a/mapper/src/test/java/com/ibm/mapper/mapper/jca/BlockCipherReorganizerTest.java
+++ b/mapper/src/test/java/com/ibm/mapper/mapper/jca/BlockCipherReorganizerTest.java
@@ -1,0 +1,127 @@
+/*
+ * Sonar Cryptography Plugin
+ * Copyright (C) 2024 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.mapper.mapper.jca;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import com.ibm.mapper.mapper.bc.BcBlockCipherEngineMapper;
+import com.ibm.mapper.mapper.bc.BcBlockCipherModeMapper;
+import com.ibm.mapper.model.Algorithm;
+import com.ibm.mapper.model.BlockCipher;
+import com.ibm.mapper.model.INode;
+import com.ibm.mapper.reorganizer.IReorganizerRule;
+import com.ibm.mapper.reorganizer.rules.BlockCipherReorganizer;
+import com.ibm.mapper.utils.DetectionLocation;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class BlockCipherReorganizerTest {
+
+    private final DetectionLocation SHARED_LOCATION_CONTEXT = mock(DetectionLocation.class);
+    private final INode DUMMY_PARENT = mock(INode.class);
+
+    @Test
+    @DisplayName(
+            "Issue #295: Should successfully deduplicate real nodes generated from AESFastEngine and SICBlockCipher")
+    void shouldDeduplicateRealBouncyCastleEngineAndModeNodes() {
+        IReorganizerRule rule = BlockCipherReorganizer.DEDUPLICATE_OVERLAPPING_ROOTS;
+
+        BcBlockCipherEngineMapper engineMapper = new BcBlockCipherEngineMapper(BlockCipher.class);
+        BcBlockCipherModeMapper modeMapper = new BcBlockCipherModeMapper();
+
+        INode aesNode =
+                engineMapper
+                        .parse("AESFastEngine", SHARED_LOCATION_CONTEXT)
+                        .orElseThrow(
+                                () ->
+                                        new IllegalStateException(
+                                                "Engine mapper failed to translate AESFastEngine"));
+
+        INode aesCtrNode =
+                modeMapper
+                        .parse("SICBlockCipher", SHARED_LOCATION_CONTEXT)
+                        .orElseThrow(
+                                () ->
+                                        new IllegalStateException(
+                                                "Mode mapper failed to translate SICBlockCipher"));
+
+        List<INode> roots = new ArrayList<>(List.of(aesNode, aesCtrNode));
+
+        boolean isMatch = rule.match(aesNode, DUMMY_PARENT, roots);
+        assertThat(isMatch)
+                .as(
+                        "The rule should detect that AESFastEngine and SICBlockCipher create overlapping roots")
+                .isTrue();
+
+        List<INode> optimizedRoots = rule.applyReorganization(aesNode, DUMMY_PARENT, roots);
+
+        assertThat(optimizedRoots).hasSize(1);
+
+        Algorithm remainingAlg = (Algorithm) optimizedRoots.get(0);
+        assertThat(remainingAlg.getName()).isEqualTo("AES");
+        assertThat(remainingAlg.getChildren()).isNotEmpty();
+    }
+
+    @Test
+    @DisplayName(
+            "Unit Test: Should merge parent and child BlockCipher nodes when the analyzer provides them as a nested tree")
+    void shouldMergeNestedParentAndChildBlockCipherNodes() {
+        IReorganizerRule rule = BlockCipherReorganizer.MERGE_BLOCK_CIPHER_PARENT_AND_CHILD;
+
+        BcBlockCipherEngineMapper engineMapper = new BcBlockCipherEngineMapper(BlockCipher.class);
+        BcBlockCipherModeMapper modeMapper = new BcBlockCipherModeMapper();
+
+        INode parentNode =
+                modeMapper
+                        .parse("SICBlockCipher", SHARED_LOCATION_CONTEXT)
+                        .orElseThrow(() -> new IllegalStateException("Mode mapper failed"));
+
+        INode childNode =
+                engineMapper
+                        .parse("AESFastEngine", SHARED_LOCATION_CONTEXT)
+                        .orElseThrow(() -> new IllegalStateException("Engine mapper failed"));
+
+        parentNode.put(childNode);
+
+        List<INode> roots = new ArrayList<>(List.of(parentNode));
+
+        boolean isMatch = rule.match(parentNode, DUMMY_PARENT, roots);
+        List<INode> optimizedRoots = rule.applyReorganization(parentNode, DUMMY_PARENT, roots);
+
+        assertThat(isMatch)
+                .as("The rule should detect the nested BlockCipher -> BlockCipher relationship")
+                .isTrue();
+
+        assertThat(optimizedRoots).hasSize(1);
+
+        INode mergedNode = optimizedRoots.get(0);
+
+        assertThat(mergedNode).isInstanceOf(Algorithm.class);
+        assertThat(mergedNode.is(BlockCipher.class)).isTrue();
+
+        assertThat(mergedNode.getChildren())
+                .as(
+                        "The merged node should retain the inner child properties (like Mode and KeyLength)")
+                .isNotEmpty();
+    }
+}

--- a/python/src/test/java/com/ibm/plugin/rules/detection/mac/PycaMacDetectionInCustomFunctionTest.java
+++ b/python/src/test/java/com/ibm/plugin/rules/detection/mac/PycaMacDetectionInCustomFunctionTest.java
@@ -44,9 +44,9 @@ import org.sonar.plugins.python.api.tree.Tree;
 import org.sonar.python.checks.utils.PythonCheckVerifier;
 
 /**
- * Verifies that cryptographic operations inside user-defined functions are detected during
- * standard AST traversal. This test covers both positive cases (cryptographic operations) and
- * negative cases (non-cryptographic functions).
+ * Verifies that cryptographic operations inside user-defined functions are detected during standard
+ * AST traversal. This test covers both positive cases (cryptographic operations) and negative cases
+ * (non-cryptographic functions).
  */
 class PycaMacDetectionInCustomFunctionTest extends TestBase {
 

--- a/python/src/test/java/com/ibm/plugin/rules/detection/mac/PycaMacDetectionInCustomFunctionTest.java
+++ b/python/src/test/java/com/ibm/plugin/rules/detection/mac/PycaMacDetectionInCustomFunctionTest.java
@@ -44,9 +44,9 @@ import org.sonar.plugins.python.api.tree.Tree;
 import org.sonar.python.checks.utils.PythonCheckVerifier;
 
 /**
- * Verifies that cryptographic operations inside user-defined functions are detected during standard
- * AST traversal. This test covers both positive cases (cryptographic operations) and negative cases
- * (non-cryptographic functions).
+ * Verifies that cryptographic operations inside user-defined functions are detected during
+ * standard AST traversal. This test covers both positive cases (cryptographic operations) and
+ * negative cases (non-cryptographic functions).
  */
 class PycaMacDetectionInCustomFunctionTest extends TestBase {
 


### PR DESCRIPTION
Fixes #295

When processing certain Bouncy Castle block cipher constructions, multiple block-cipher-related nodes can be produced for the same source location. The existing deduplication logic relied on strict checks against the BlockCipher interface, which prevented some algorithm nodes from participating in reorganization even when they represented block-cipher assets.

This change updates the deduplication rule to operate on Algorithm nodes while preserving the existing BlockCipher node-kind filtering. It also adds null-safe handling for algorithm names and improves merging behavior when generic wrapper nodes are encountered.

Tests were added to cover:
- overlapping block cipher roots generated from the Bouncy Castle engine and mode mappings
- nested parent/child block cipher structures processed by the reorganizer