### PR TITLE
fixes handling of *args and **kwargs

### DIFF
--- a/engine/src/main/java/com/ibm/engine/language/python/PythonLanguageTranslation.java
+++ b/engine/src/main/java/com/ibm/engine/language/python/PythonLanguageTranslation.java
@@ -90,13 +90,33 @@ public class PythonLanguageTranslation implements ILanguageTranslation<Tree> {
         if (methodInvocation instanceof CallExpression callExpression) {
             List<Argument> arguments = callExpression.arguments();
             if (!arguments.isEmpty()) {
+                // Count ALL argument types including *args and **kwargs to prevent false matches
+                // when rules specify .withoutParameters()
                 return arguments.stream()
-                        .filter(RegularArgument.class::isInstance)
-                        // Should non-regular argument types be handled?
-                        .map(
-                                argument ->
-                                        PythonSemantic.resolveTreeType(
-                                                ((RegularArgument) argument).expression()))
+                        .<Optional<IType>>map(
+                                argument -> {
+                                    if (argument instanceof RegularArgument regularArg) {
+                                        return PythonSemantic.resolveTreeType(
+                                                regularArg.expression());
+                                    } else {
+                                        // For non-regular arguments (*args, **kwargs), return a
+                                        // placeholder type
+                                        // that will never match any specific type in detection
+                                        // rules.
+                                        // This ensures they are counted as parameters without
+                                        // matching wildcards.
+                                        return Optional.<IType>of(
+                                                new IType() {
+                                                    @Override
+                                                    public boolean is(@Nonnull String type) {
+                                                        // Use unique markers that won't conflict
+                                                        // with actual types or wildcards
+                                                        return type.equals("__PYTHON_VARARGS__")
+                                                                || type.equals("__PYTHON_KWARGS__");
+                                                    }
+                                                });
+                                    }
+                                })
                         .filter(Optional::isPresent)
                         .map(Optional::get)
                         .toList();

--- a/python/src/main/java/com/ibm/plugin/rules/detection/keyagreement/PycaKeyAgreement.java
+++ b/python/src/main/java/com/ibm/plugin/rules/detection/keyagreement/PycaKeyAgreement.java
@@ -43,7 +43,7 @@ public final class PycaKeyAgreement {
                             "cryptography.hazmat.primitives.asymmetric.x25519.X25519PrivateKey")
                     .forMethods("generate")
                     .shouldBeDetectedAs(new KeyActionFactory<>(KeyAction.Action.GENERATION))
-                    .withAnyParameters()
+                    .withoutParameters()
                     .buildForContext(new KeyAgreementContext(Map.of("algorithm", "x25519")))
                     .inBundle(() -> "Pyca")
                     .withoutDependingDetectionRules();
@@ -54,7 +54,7 @@ public final class PycaKeyAgreement {
                     .forObjectTypes("cryptography.hazmat.primitives.asymmetric.x448.X448PrivateKey")
                     .forMethods("generate")
                     .shouldBeDetectedAs(new KeyActionFactory<>(KeyAction.Action.GENERATION))
-                    .withAnyParameters()
+                    .withoutParameters()
                     .buildForContext(new KeyAgreementContext(Map.of("algorithm", "x448")))
                     .inBundle(() -> "Pyca")
                     .withoutDependingDetectionRules();

--- a/python/src/test/files/rules/detection/asymmetric/EllipticCurve/PycaEllipticCurveSign2TestFile.py
+++ b/python/src/test/files/rules/detection/asymmetric/EllipticCurve/PycaEllipticCurveSign2TestFile.py
@@ -13,6 +13,23 @@ public_key = private_key.public_key()
 # Raises InvalidSignature if verification fails
 public_key.verify(signature, b"my authenticated message")
 
+# False positives that should NOT be detected (PR-429 fix)
+# These are unrelated generate() methods with parameters
+class VLMModel:
+    def generate(self, **gen_kwargs):
+        return [1, 2, 3]
+
+class TextModel:
+    def generate(self, *prompts):
+        return "generated text"
+
+vlm_model = VLMModel()
+text_model = TextModel()
+
+# These should NOT trigger detection (not cryptography-related)
+generated_ids = vlm_model.generate(**{"max_length": 100})
+generated_text = text_model.generate("prompt1", "prompt2")
+
 # GROUND TRUTH (translation of the 1st finding)
 # 
 # PrivateKey EC

--- a/python/src/test/files/rules/detection/keyagreement/PycaKeyAgreementTestFile.py
+++ b/python/src/test/files/rules/detection/keyagreement/PycaKeyAgreementTestFile.py
@@ -19,3 +19,20 @@ private_key = X448PrivateKey.generate() # Noncompliant {{(KeyAgreement) x448}}
 # must agree on a common set of parameters.
 peer_public_key = X448PrivateKey.generate().public_key() # Noncompliant {{(KeyAgreement) x448}}
 shared_key = private_key.exchange(peer_public_key)
+
+# False positives that should NOT be detected (PR-429 fix)
+# These are unrelated generate() methods with parameters
+class DataGenerator:
+    def generate(self, **kwargs):
+        return [1, 2, 3]
+
+class ModelGenerator:
+    def generate(self, *args):
+        return "generated"
+
+data_gen = DataGenerator()
+model_gen = ModelGenerator()
+
+# These should NOT trigger detection (not cryptography-related)
+result1 = data_gen.generate(**{"size": 100})
+result2 = model_gen.generate("prompt1", "prompt2")

--- a/python/src/test/java/com/ibm/plugin/rules/detection/mac/PycaMacDetectionInCustomFunctionTest.java
+++ b/python/src/test/java/com/ibm/plugin/rules/detection/mac/PycaMacDetectionInCustomFunctionTest.java
@@ -44,9 +44,9 @@ import org.sonar.plugins.python.api.tree.Tree;
 import org.sonar.python.checks.utils.PythonCheckVerifier;
 
 /**
- * Verifies that cryptographic operations inside user-defined functions are detected during
- * standard AST traversal. This test covers both positive cases (cryptographic operations) and
- * negative cases (non-cryptographic functions).
+ * Verifies that cryptographic operations inside user-defined functions are detected during standard
+ * AST traversal. This test covers both positive cases (cryptographic operations) and negative cases
+ * (non-cryptographic functions).
  */
 class PycaMacDetectionInCustomFunctionTest extends TestBase {
 


### PR DESCRIPTION
This PR builds upon #429 and fixes #300. Core reason for false positives was the incorrect handling of extra positional arguments *args and **kwargs. The PR also extends existing tests to cover FP cases.