### PR TITLE
Enable DuplicateDependingFindingsTest

### DIFF
--- a/java/src/test/files/rules/issues/DuplicateDependingFindingsTestFile.java
+++ b/java/src/test/files/rules/issues/DuplicateDependingFindingsTestFile.java
@@ -13,9 +13,9 @@ public class DuplicateDependingFindingsTestFile {
 
     public byte[] encryptCEK(final RSAPublicKey pub, final SecretKey cek)
     throws RuntimeException {
-        AsymmetricBlockCipher engine = new RSAEngine(); // Noncompliant {{RSA}}
+        AsymmetricBlockCipher engine = new RSAEngine(); // Noncompliant {{(PublicKeyEncryption) RSA}}
 
-        OAEPEncoding oaep = new OAEPEncoding(engine); // Noncompliant {{OAEP}}
+        OAEPEncoding oaep = new OAEPEncoding(engine); // Noncompliant {{(PublicKeyEncryption) RSA-OAEP}}
 
         oaep.init(true, new RSAKeyParameters(false, null, null));
 

--- a/java/src/test/java/com/ibm/plugin/rules/issues/DuplicateDependingFindingsTest.java
+++ b/java/src/test/java/com/ibm/plugin/rules/issues/DuplicateDependingFindingsTest.java
@@ -27,14 +27,13 @@ import com.ibm.engine.model.OperationMode;
 import com.ibm.engine.model.ValueAction;
 import com.ibm.engine.model.context.CipherContext;
 import com.ibm.mapper.model.INode;
+import com.ibm.mapper.model.Padding;
 import com.ibm.mapper.model.PublicKeyEncryption;
 import com.ibm.mapper.model.functionality.Encrypt;
-import com.ibm.mapper.model.padding.OAEP;
 import com.ibm.plugin.TestBase;
 import com.ibm.plugin.rules.detection.bc.BouncyCastleJars;
 import java.util.List;
 import javax.annotation.Nonnull;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.sonar.java.checks.verifier.CheckVerifier;
 import org.sonar.plugins.java.api.JavaCheck;
@@ -56,7 +55,6 @@ class DuplicateDependingFindingsTest extends TestBase {
      * a major priority issue because this duplicate does not create confusion and can easily be
      * removed at translation.
      */
-    @Disabled
     @Test
     void test() {
         CheckVerifier.newVerifier()
@@ -83,7 +81,7 @@ class DuplicateDependingFindingsTest extends TestBase {
         assertThat(detectionStore.getDetectionValueContext()).isInstanceOf(CipherContext.class);
         IValue<Tree> value0 = detectionStore.getDetectionValues().get(0);
         assertThat(value0).isInstanceOf(ValueAction.class);
-        assertThat(value0.asString()).isEqualTo("OAEP");
+        assertThat(value0.asString()).isEqualTo("OAEPEncoding");
 
         DetectionStore<JavaCheck, Tree, Symbol, JavaFileScannerContext> store_1 =
                 getStoreOfValueType(OperationMode.class, detectionStore.getChildren());
@@ -99,7 +97,7 @@ class DuplicateDependingFindingsTest extends TestBase {
         assertThat(store_2.getDetectionValueContext()).isInstanceOf(CipherContext.class);
         IValue<Tree> value0_2 = store_2.getDetectionValues().get(0);
         assertThat(value0_2).isInstanceOf(ValueAction.class);
-        assertThat(value0_2.asString()).isEqualTo("RSA");
+        assertThat(value0_2.asString()).isEqualTo("RSAEngine");
 
         DetectionStore<JavaCheck, Tree, Symbol, JavaFileScannerContext> store_2_1 =
                 getStoreOfValueType(OperationMode.class, store_2.getChildren());
@@ -116,7 +114,7 @@ class DuplicateDependingFindingsTest extends TestBase {
         INode publicKeyEncryptionNode = nodes.get(0);
         assertThat(publicKeyEncryptionNode.getKind()).isEqualTo(PublicKeyEncryption.class);
         assertThat(publicKeyEncryptionNode.getChildren()).hasSize(3);
-        assertThat(publicKeyEncryptionNode.asString()).isEqualTo("RSA");
+        assertThat(publicKeyEncryptionNode.asString()).isEqualTo("RSA-OAEP");
 
         // Encrypt under PublicKeyEncryption
         INode encryptNode = publicKeyEncryptionNode.getChildren().get(Encrypt.class);
@@ -126,7 +124,7 @@ class DuplicateDependingFindingsTest extends TestBase {
 
         // OptimalAsymmetricEncryptionPadding under PublicKeyEncryption
         INode optimalAsymmetricEncryptionPaddingNode =
-                publicKeyEncryptionNode.getChildren().get(OAEP.class);
+                publicKeyEncryptionNode.getChildren().get(Padding.class);
         assertThat(optimalAsymmetricEncryptionPaddingNode).isNotNull();
         assertThat(optimalAsymmetricEncryptionPaddingNode.getChildren()).isEmpty();
         assertThat(optimalAsymmetricEncryptionPaddingNode.asString()).isEqualTo("OAEP");

--- a/java/src/test/java/com/ibm/plugin/rules/issues/DuplicateDependingFindingsTest.java
+++ b/java/src/test/java/com/ibm/plugin/rules/issues/DuplicateDependingFindingsTest.java
@@ -50,10 +50,9 @@ class DuplicateDependingFindingsTest extends TestBase {
      * called (`oaep.init(...)`). The engine has the same depending detection rule, but it shouldn't
      * be triggered because it is not called for the engine (there is no `engine.init(...)`).
      *
-     * <p>The issue is here at the level of the detection store: the `init` depending detection rule
-     * is called both for the `OAEPEncoding` (expected) and for its engine (unexpected). This is not
-     * a major priority issue because this duplicate does not create confusion and can easily be
-     * removed at translation.
+     * <p>This test verifies that at the level of the detection store, the `init` depending on detection rule
+     * is correctly called only for the `OAEPEncoding` (expected) and not for its engine (unexpected),
+     * ensuring duplicate depending on findings are not propagated.
      */
     @Test
     void test() {

--- a/java/src/test/java/com/ibm/plugin/rules/issues/DuplicateDependingFindingsTest.java
+++ b/java/src/test/java/com/ibm/plugin/rules/issues/DuplicateDependingFindingsTest.java
@@ -50,9 +50,9 @@ class DuplicateDependingFindingsTest extends TestBase {
      * called (`oaep.init(...)`). The engine has the same depending detection rule, but it shouldn't
      * be triggered because it is not called for the engine (there is no `engine.init(...)`).
      *
-     * <p>This test verifies that at the level of the detection store, the `init` depending on detection rule
-     * is correctly called only for the `OAEPEncoding` (expected) and not for its engine (unexpected),
-     * ensuring duplicate depending on findings are not propagated.
+     * <p>This test verifies that at the level of the detection store, the `init` depending on
+     * detection rule is correctly called only for the `OAEPEncoding` (expected) and not for its
+     * engine (unexpected), ensuring duplicate depending on findings are not propagated.
      */
     @Test
     void test() {

--- a/python/src/main/java/com/ibm/plugin/translation/translator/contexts/PycaDigestContextTranslator.java
+++ b/python/src/main/java/com/ibm/plugin/translation/translator/contexts/PycaDigestContextTranslator.java
@@ -41,8 +41,7 @@ public final class PycaDigestContextTranslator implements IContextTranslation<Tr
             @Nonnull IValue<Tree> value,
             @Nonnull IDetectionContext detectionContext,
             @Nonnull DetectionLocation detectionLocation) {
-        if (value instanceof ValueAction<Tree>
-        || value instanceof com.ibm.engine.model.Algorithm) {
+        if (value instanceof ValueAction<Tree> || value instanceof com.ibm.engine.model.Algorithm) {
             final PycaDigestMapper pycaDigestMapper = new PycaDigestMapper();
             return pycaDigestMapper
                     .parse(value.asString(), detectionLocation)


### PR DESCRIPTION
This PR enables `DuplicateDependingFindingsTest`, which was previously disabled due to duplicate depending detection rules being propagated from `OAEPEncoding` to its child `RSAEngine`. The test assertions have been updated to verify that the `init` depending detection rule is only associated with `OAEPEncoding` and not the underlying engine. This adds regression coverage and helps prevent duplicate findings from being reintroduced.

Also fixed spotless errors in PycaDigestContextTranslator.java